### PR TITLE
ensure Zeus::SOCKET_NAME is cleaned up

### DIFF
--- a/lib/zeus/server.rb
+++ b/lib/zeus/server.rb
@@ -90,6 +90,8 @@ module Zeus
         end if rs
       end
 
+    ensure
+      File.unlink(Zeus::SOCKET_NAME)
     end
 
     def handle_messages


### PR DESCRIPTION
This was fixed in a previous PR, not sure what happened.
