### PR TITLE
Intermitted WINCH is sent before we have a pid.

### DIFF
--- a/lib/zeus/client.rb
+++ b/lib/zeus/client.rb
@@ -63,7 +63,7 @@ module Zeus
     def handle_winch
       @winch.read(1)
       set_winsize
-      Process.kill("WINCH", pid)
+      Process.kill("WINCH", pid) if pid
     end
 
     def handle_stdin(buffer)


### PR DESCRIPTION
Lukcily nil does not coerce to 4 in this context. Instead we simply get
an error.

The included "fix" obviously prevents the crash in question, but does
indicate an underlying issue. Which will need further investigation.
