### PR TITLE
show exit status not returned correctly

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -7,20 +7,27 @@ describe "Integration" do
 
   context "in a non-rails project with a .zeus.rb" do
     it "starts the zeus server and responds to commands" do
-      write ".zeus.rb", <<-RUBY
-        Zeus::Server.define! do
-          stage :foo do
-            command :bar do
-              puts "YES"
-            end
-          end
-        end
-      RUBY
-
+      bar_setup("puts 'YES'")
       start, run = start_and_run("bar")
       start.should include "spawner `foo`"
       start.should include "acceptor `bar`"
       run.should == ["YES\r\n"]
+    end
+
+    it "receives ARGV after command" do
+      bar_setup("puts ARGV.join(', ')")
+      start, run = start_and_run("bar 1 '2 3 4' --123")
+      run.should == ["1, 2 3 4, --123\r\n"]
+    end
+
+    it "cam exist with 0" do
+      bar_setup("exit 0")
+      start_and_run("bar")
+    end
+
+    it "can exist with non-0" do
+      bar_setup("exit 1")
+      start_and_run("bar", :fail => true)
     end
 
     it "can run via command alias" do
@@ -43,6 +50,18 @@ describe "Integration" do
 
   private
 
+  def bar_setup(inner)
+    write ".zeus.rb", <<-RUBY
+      Zeus::Server.define! do
+        stage :foo do
+          command :bar do
+            #{inner}
+          end
+        end
+      end
+    RUBY
+  end
+
   def zeus(command, options={})
     command = zeus_command(command)
     result = `#{command}`
@@ -62,11 +81,11 @@ describe "Integration" do
     end
   end
 
-  def start_and_run(commands)
+  def start_and_run(commands, options={})
     start_output = ""
     t1 = Thread.new { record_start(start_output) }
     sleep 0.1
-    run_output = [*commands].map{ |cmd| zeus(cmd) }
+    run_output = [*commands].map{ |cmd| zeus(cmd, options) }
     sleep 0.2
     t1.kill
     [start_output, run_output]


### PR DESCRIPTION
Tried to fix it but did not get far, maybe you can make these pass, otherwise I'll try again later...

basic issue is that the exit status is not returned correctly -> `zeus testrb foo && xxx` always runs xxx
