### PR TITLE
warn about bundle-exec early

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require "bundler/gem_tasks"
 
 require 'rspec/core/rake_task'
 task :spec do
+  raise "tests do not work with bundle exec" if defined?(Bundler)
   desc "Run specs under spec/"
   RSpec::Core::RakeTask.new do |t|
     t.pattern = 'spec/**/*_spec.rb'


### PR DESCRIPTION
my env does bundle exec by default / it's usually good practice to to bundle exec rake, so this is a fast reminder to not use it here
