### PR TITLE
warn about bundle exec instead of failing all the time

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,11 +3,13 @@ require "bundler/gem_tasks"
 
 require 'rspec/core/rake_task'
 task :spec do
-  raise "tests do not work with bundle exec" if defined?(Bundler)
   desc "Run specs under spec/"
   RSpec::Core::RakeTask.new do |t|
     t.pattern = 'spec/**/*_spec.rb'
   end
 end
 
-task default: :spec
+task :default do
+  puts "rake fails when run via bundle exec"
+  Rake::Task["spec"].invoke
+end


### PR DESCRIPTION
no idea how the other ever worked, 
bundler/gemtasks always defines Bundler
