### PR TITLE
Fix cucumber environment/command

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -158,12 +158,12 @@ module Zeus
     def cucumber_environment
       require 'cucumber/rspec/disable_option_parser'
       require 'cucumber/cli/main'
-      cucumber_runtime = Cucumber::Runtime.new
+      @cucumber_runtime = Cucumber::Runtime.new
     end
 
     def cucumber
       cucumber_main = Cucumber::Cli::Main.new(ARGV.dup)
-      exit cucumber_main.execute!(cucumber_runtime)
+      exit cucumber_main.execute!(@cucumber_runtime)
     end
 
     private


### PR DESCRIPTION
Make cucumber runtime available within cucumber command via use of an ivar as
opposed to a local.
