### PR TITLE
Correct 'zeus commands' to 'zeus help' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Start the server:
 
 See a list of the available commands:
 
-    zeus commands
+    zeus help
 
 Run some commands:
 


### PR DESCRIPTION
'zeus commands' isn't recognised by 0.4.6, I'm guessing this is a mistake in the README.
