### PR TITLE
Run MiniTest tests in both 1.8 and 1.9 (undefined method `runner' for MiniTest::Unit:Class)

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -216,7 +216,7 @@ module Zeus
         # directly run the tests from here and exit with the status of the tests passing or failing
         case framework
         when :minitest
-          exit MiniTest::Unit.runner.run test_arguments
+          exit MiniTest::Unit.new.run test_arguments
         when :testunit1, :testunit2
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else


### PR DESCRIPTION
This fixes error:

```
$ zeus test test/unit/user_test.rb                
/Users/jason/.rvm/gems/ruby-1.9.2-p290/gems/zeus-0.12.0/lib/zeus/m.rb:219:in `execute': undefined method `runner' for MiniTest::Unit:Class (NoMethodError)
    from /Users/jason/.rvm/gems/ruby-1.9.2-p290/gems/zeus-0.12.0/lib/zeus/m.rb:121:in `run'
```

In the minitest gem (used only on Ruby 1.8), MiniTest::Unit.runner delegates to MiniTest::Unit.new and memoizes the result.  This method is not available in the Ruby 1.9 stdlib minitest, so we just instantiate a new MiniTest::Unit for cross-compatibility.

In 1.8 minitest gem, see [class method MiniTest::Unit.runner](https://github.com/seattlerb/minitest/blob/bdbf38df3475dcc8ddd6d11ebede48cdd5f55008/lib/minitest/unit.rb#L808-815).

In 1.9, get a runner instance by constructing a new MiniTest::Unit.  See [1.9.2 method](https://github.com/ruby/ruby/blob/v1_9_2_381/lib/minitest/unit.rb#L551-L590) and
[1.9.3 method](https://github.com/ruby/ruby/blob/v1_9_3_286/lib/minitest/unit.rb#L531-L883).
