### PR TITLE
#148: zeus test uses rspec only if we are running a spec file

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -164,7 +164,7 @@ module Zeus
     end
 
     def test
-      if defined?(RSpec)
+      if spec_file?(ARGV) && defined?(RSpec)
         exit RSpec::Core::Runner.run(ARGV)
       else
         Zeus::M.run(ARGV)
@@ -184,6 +184,15 @@ module Zeus
 
 
     private
+
+    SPEC_FILE_REGEXP = /.+_spec\.rb$/
+    def spec_file? argv
+      SPEC_FILE_REGEXP.match(first_ruby_file argv) != nil
+    end
+
+    def first_ruby_file argv
+      argv.find { |e| /.+\.rb$/ =~ e }
+    end
 
     def restart_girl_friday
       return unless defined?(GirlFriday::WorkQueue)


### PR DESCRIPTION
In order to run other ruby test frameworks like Test::Unit in a project
that defines Rspec (because it uses both test frameworks), we check if
the file match /.+_spec.rb$/. If it doesn't, then we use Zeus::M to run
the file.
