### PR TITLE
Update to link to gist for ruby 1.9.3-p286 (instead of ruby-1.9.3-p194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More technically speaking, Zeus is a language-agnostic application checkpointer 
 * Rails 3.0+ (Support for other versions is not difficult and is planned.)
 * Ruby 1.9.3+ with backported GC from Ruby 2.0 *OR* Rubinius
 
-You can install the GC-patched ruby from [this gist](https://gist.github.com/1688857) or from RVM. This is not actually 100% necessary, especially if you have a lot of memory. Feel free to give it a shot first without, but if you're suddenly out of RAM, switching to the GC-patched ruby will fix it.
+You can install the GC-patched ruby from [this gist](https://gist.github.com/3885178) or from RVM. This is not actually 100% necessary, especially if you have a lot of memory. Feel free to give it a shot first without, but if you're suddenly out of RAM, switching to the GC-patched ruby will fix it.
 
 ## Installation
 


### PR DESCRIPTION
Updating to latest ruby.

Also, thanks. This is great.
