### PR TITLE
Add manpages as a dependency to `make gem`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ fmt:
 manpages:
 	cd man; /usr/bin/env rake
 
-gem: fsevents
+gem: fsevents manpages
 	mkdir -p rubygem/ext/fsevents-wrapper
 	cp -r examples rubygem
 	cp build/fsevents-wrapper rubygem/ext/fsevents-wrapper


### PR DESCRIPTION
Running `make gem` will fail unless manpages are generated.
