### PR TITLE
require 'irb' in console to set the IRB constant

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -125,6 +125,7 @@ module Zeus
     end
 
     def console
+      require 'irb'
       if defined?(Pry) && IRB == Pry
         require "pry"
         Pry.start 


### PR DESCRIPTION
without this, the console task fails with uninitialized constant Zeus::Rails::IRB

After a fresh Zeus init and start:

```
$ zeus console
[…]zeus-0.13.1/lib/zeus/rails.rb:128:in `console': uninitialized constant Zeus::Rails::IRB (NameError)
```
