### PR TITLE
Better `spec_file?` logic

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -203,13 +203,11 @@ module Zeus
 
     private
 
+    SPEC_DIR_REGEXP = /^spec/
     SPEC_FILE_REGEXP = /.+_spec\.rb$/
     def spec_file? argv
-      SPEC_FILE_REGEXP.match(first_ruby_file argv) != nil
-    end
-
-    def first_ruby_file argv
-      argv.find { |e| /.+\.rb$/ =~ e }
+      last_arg = argv[-1]
+      last_arg.match (Regexp.union(SPEC_DIR_REGEXP, SPEC_FILE_REGEXP))
     end
 
     def restart_girl_friday


### PR DESCRIPTION
The current logic has two problems.
1. Doesn't detect "spec" argument as triggering Rspec runner, erroneously uses M instead.
2. When an earlier argument is a Ruby file that isn't a spec (such as `formatter.rb`) the spec detection gives false negative because it doesn't match the spec pattern.

This fix looks at the last argument instead (where options won't be) and matches on /^spec/. I think that's the only regexp necessary, but I left SPEC_FILE_REGEXP that was already there.
