### PR TITLE
require rails console before checking IRB constant

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -125,12 +125,11 @@ module Zeus
     end
 
     def console
-      require 'irb'
+      require 'rails/commands/console'
       if defined?(Pry) && IRB == Pry
         require "pry"
         Pry.start 
       else
-        require 'rails/commands/console'
         ::Rails::Console.start(::Rails.application)
       end 
     end


### PR DESCRIPTION
This is a fix for the error where `Zeus::Rails::IRB` constant is undefined when using `zeus console` and Pry as reported in issue #215.
