### PR TITLE
Add travis-ci configuration which runs ruby specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# Not using to test compilation of go component of project because it requires
+# xcodebuild which is not available in the ubuntu environment travis-ci
+# provides.
+language: ruby
+rvm:
+  - 1.9.3
+gemfile: rubygem/Gemfile
+script: cd rubygem && rake version && bundle exec rspec spec
+


### PR DESCRIPTION
This currently fails, see issue #220.

Once this pull request is landed on master the travis-ci hook will need activating for the project, see [travis-ci's getting started guide](http://about.travis-ci.org/docs/user/getting-started/)
