### PR TITLE
don't manage redis connections in test

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -29,7 +29,7 @@ module Zeus
     def after_fork
       reconnect_activerecord
       restart_girl_friday
-      reconnect_redis
+      reconnect_redis unless Rails.env.test?
     end
 
     def _monkeypatch_rake


### PR DESCRIPTION
as alluded to in #123, allow users of zeus to self
manage their redis connections in test.
