### PR TITLE
Fix running Test::Unit under Ruby 1.9.3

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -200,7 +200,7 @@ module Zeus
           nerf_test_unit_autorunner
           exit_code = nil
           at_exit { exit false if exit_code && exit_code != 0 }
-          exit_code = MiniTest::Unit.runner.run test_arguments
+          exit_code = MiniTest::Unit.new.run test_arguments
         when :testunit1, :testunit2
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else


### PR DESCRIPTION
Fixes burke/zeus#226

Fix originally from https://github.com/qrush/m/pull/21
