### PR TITLE
Fix for Issue #254

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -59,7 +59,7 @@ module Zeus
 
       # We are now 'connected'. From this point, we may receive requests to fork.
       loop do
-        messages = local.recv(1024)
+        messages = local.recv(2**16)
         messages.split("\0").each do |new_identifier|
           new_identifier =~ /^(.):(.*)/
           code, ident = $1, $2


### PR DESCRIPTION
This fix just extends the number of characters that can be sent on the command line from 1024 to 2**16.  Without this, Zeus does not work in RubyMine and other test shells.
