### PR TITLE
Release AR connections in test helper

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -129,10 +129,10 @@ module Zeus
       require 'rails/commands/console'
       if defined?(Pry) && IRB == Pry
         require "pry"
-        Pry.start 
+        Pry.start
       else
         ::Rails::Console.start(::Rails.application)
-      end 
+      end
     end
 
     def dbconsole
@@ -179,6 +179,7 @@ module Zeus
       else
         require 'test_helper'
       end
+      ActiveRecord::Base.clear_all_connections! if defined?(ActiveRecord::Base)
     end
 
     def test


### PR DESCRIPTION
Executing `zeus rake test:prepare` as the first command after `zeus start` fails complaining that the database is being accessed by other users.

However, after executing `zeus test my_spec`, `zeus rake test:prepare` goes through.

I believe this is because the AR connection is associated with the test helper is not released.

This patch immediately releases the AR connection allowing `zeus rake test:prepare` to complete successfully.
