### PR TITLE
Use kr's PTY for improved OS X client behavior

### DIFF
--- a/dev-bootstrap.sh
+++ b/dev-bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 go get github.com/burke/ttyutils
 go install github.com/burke/ttyutils
-go get github.com/burke/pty
-go install github.com/burke/pty
+go get github.com/kr/pty
+go install github.com/kr/pty

--- a/go/zeusclient/zeusclient.go
+++ b/go/zeusclient/zeusclient.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/burke/pty"
+	"github.com/kr/pty"
 	"github.com/burke/ttyutils"
 	"github.com/burke/zeus/go/messages"
 	slog "github.com/burke/zeus/go/shinylog"


### PR DESCRIPTION
Building the gem with burke's PTY branch, I reproducibly get failures to open the PTY on OS X (10.8.2) of the form:

```
zeusclient.go:48: open /dev/ttys012: invalid argument
```

Using kr's PTY library, there are no such problems and zeus can start clients properly. Since kr has upgraded the upstream version of PTY to support Darwin (and his works so much better for me), I'd suggest changing over to that one.
