### PR TITLE
Don't terminate on SIGPIPE

### DIFF
--- a/go/zeusmaster/zeusmaster.go
+++ b/go/zeusmaster/zeusmaster.go
@@ -15,7 +15,8 @@ import (
 )
 
 // man signal | grep 'terminate process' | awk '{print $2}' | xargs -I '{}' echo -n "syscall.{}, "
-var terminatingSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGPIPE, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGXCPU, syscall.SIGXFSZ, syscall.SIGVTALRM, syscall.SIGPROF, syscall.SIGUSR1, syscall.SIGUSR2}
+// Leaving out SIGPIPE as that is a signal the master receives if a client process is killed.
+var terminatingSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGXCPU, syscall.SIGXFSZ, syscall.SIGVTALRM, syscall.SIGPROF, syscall.SIGUSR1, syscall.SIGUSR2}
 
 func Run() {
 	os.Exit(doRun())


### PR DESCRIPTION
Zeus server receives SIGPIPE when a client quits unexpectedly (when it
gets killed, for any reason). This should not cause the server to
terminate; the go default SIGPIPE handler causes the server to react
correctly and remain alive and responsive (despite complaining about
the broken pipe).

I think this should take care of #239 and potentially @rosenfeld's "broken pipe" errors in #226.
