### PR TITLE
Better subprocess handling

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -118,14 +118,17 @@ module Zeus
 
       kill_command_if_client_quits!(pid, client_pid)
 
-      at_exit{ Process.kill(:TERM, client_pid) }
-
       Process.wait(pid)
       code = $?.exitstatus || 0
 
       local.write "#{code}\0"
 
       local.close
+    rescue Exception
+      # If anything at all went wrong, kill the client - if anything
+      # went wrong before the runner can clean up, it might hang
+      # around forever.
+      Process.kill(:TERM, client_pid)
     end
 
     def kill_command_if_client_quits!(command_pid, client_pid)


### PR DESCRIPTION
This addresses #252 and another issue where the zeus slave would leave zombie runner processes around (one per command ever having been run, until a restart happened).

I'm pretty confident that the fix for #252 is what we want. 

The parent commit of that (waiting for runner processes) should also be desirable, but the technique it uses trades off implementation simplicity for precision: While this no longer leaves around O(times a command was run) zombies around, it now leaves around 1 zombie per distinct command per slave (because it reaps only after a new command was read from the command pipe). I'm pretty sure this is still better than what was there before, but would love a suggestion for a better technique that preserves the simplicity of that command loop and ends up working better than this fix (-:
