### PR TITLE
Another fix for #254

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -94,7 +94,7 @@ module Zeus
       remote.close
       sock.close
 
-      pid_and_arguments = local.recv(1024) # if starting client before boot slave is latched, we get stuck here. We also get stuck here in #182.
+      pid_and_arguments = local.recv(2**16) # if starting client before boot slave is latched, we get stuck here. We also get stuck here in #182.
       pid_and_arguments.chomp!("\0")
       pid_and_arguments =~ /(.*?):(.*)/
       client_pid, arguments = $1.to_i, $2


### PR DESCRIPTION
This is to fix the same problem reported in #254; 
Even with the fix in #255, I'm still seeing this issue. I'm not using extraordinarily large lists of files, even. The total size of the incoming `pid_and_arguments` is only 1530 bytes in my case. 

I chose 2**16 to match what @andyl did in adc5766d

I don't see how it would affect this, but I'm using Ruby 2.0.0-p0; haven't tested on 1.9.
