### PR TITLE
Allow to pass arguments to cucumber method

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -197,8 +197,8 @@ module Zeus
       @cucumber_runtime = Cucumber::Runtime.new
     end
 
-    def cucumber
-      cucumber_main = Cucumber::Cli::Main.new(ARGV.dup)
+    def cucumber(argv=ARGV)
+      cucumber_main = Cucumber::Cli::Main.new(argv.dup)
       had_failures = cucumber_main.execute!(@cucumber_runtime)
       exit_code = had_failures ? 1 : 0
       exit exit_code


### PR DESCRIPTION
Yet another change which should be done in zeus gem to avoid monkey patching in zeus-parallel_tests ;)
