### PR TITLE
Require bundled rake version

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -33,6 +33,9 @@ module Zeus
     end
 
     def _monkeypatch_rake
+      if version = gem_is_bundled?('rake')
+        gem 'rake', version
+      end
       require 'rake/testtask'
       Rake::TestTask.class_eval {
 


### PR DESCRIPTION
`require 'rake/testtask'` uses the latest rake version. Zeus fails to start if this version does not match the bundled rake version, i.e. the one specified in Gemfile.lock:

> You have already activated rake 10.0.4, but your Gemfile requires rake 10.0.3.

This fix explicitly requires the rake version as specified in Gemfile.lock.
