### PR TITLE
Fixed broken tests and made minitest exit simpler.

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -198,9 +198,7 @@ module Zeus
         case framework
         when :minitest
           nerf_test_unit_autorunner
-          exit_code = nil
-          at_exit { exit false if exit_code && exit_code != 0 }
-          exit_code = MiniTest::Unit.runner.run test_arguments
+          exit(MiniTest::Unit.runner.run(test_arguments).to_i)
         when :testunit1, :testunit2
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else


### PR DESCRIPTION
Tests are failing.  This resolves the test issues.  I think the primary reason was [this commit](https://github.com/panthomakos/zeus/commit/36813824).

By converting the `MiniTest::Unit.runner.run` return value to an integer, you don't have to perform any complex logic around the exit code because `nil.to_i == 0`. Also, because `exit` was never explicitly called, the tests were failing.
