### PR TITLE
Definition causes a already defines constant error

### DIFF
--- a/rubygem/spec/spec_helper.rb
+++ b/rubygem/spec/spec_helper.rb
@@ -1,9 +1,5 @@
 require 'zeus/rails'
 
-module Zeus::M
-  VERSION = "0.0.0.test"
-end
-
 RSpec::Matchers.define :exit_with_code do |exp_code|
   actual = nil
   match do |block|


### PR DESCRIPTION
Defining the version in the spec_helper causes a already defined
constant warning, and since it is not really needed I guess it can just
be removed

Thoughts?
