### PR TITLE
Fix issue with test names not escaping special characters

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -219,7 +219,7 @@ module Zeus
           abort_with_no_test_found_by_line_number if @tests_to_run.empty?
 
           # assemble the regexp to run these tests,
-          test_names = @tests_to_run.map(&:name).join('|')
+          test_names = @tests_to_run.map(&:escaped_name).join('|')
 
           # set up the args needed for the runner
           ["-n", "/(#{test_names})/"]
@@ -246,7 +246,7 @@ module Zeus
         # For every test ordered by line number,
         # spit out the test name and line number where it starts,
         tests.by_line_number do |test|
-          message << "#{sprintf("%0#{tests.column_size}s", test.name)}: zeus test #{@files[0]}:#{test.start_line}\n"
+          message << "#{sprintf("%0#{tests.column_size}s", test.escaped_name)}: zeus test #{@files[0]}:#{test.start_line}\n"
         end
 
         # fail like a good unix process should.
@@ -254,7 +254,7 @@ module Zeus
       end
 
       def test_name_to_s
-        @test_name.is_a?(Regexp)? "/#{@test_name.source}/" : @test_name
+        @test_name.is_a?(Regexp)? "/#{Regexp.escape(@test_name.source)}/" : Regexp.escape(@test_name)
       end
 
       def user_specified_name?

--- a/rubygem/lib/zeus/m/test_method.rb
+++ b/rubygem/lib/zeus/m/test_method.rb
@@ -30,6 +30,10 @@ module Zeus
         # Shove the given attributes into a new databag
         new(test_method, start_line, end_line)
       end
+
+      def escaped_name
+        Regexp.escape(name)
+      end
     end
   end
 end

--- a/rubygem/spec/fake_mini_test.rb
+++ b/rubygem/spec/fake_mini_test.rb
@@ -20,12 +20,23 @@ def fake_suite
                   :instance_method => fake_instance_method)
 end
 
+def fake_suite_with_special_characters
+  @suite ||= stub("TestSuite",
+                  :test_methods => [fake_special_characters_test_method],
+                  :instance_method => fake_instance_method(fake_special_characters_test_method))
+end
+
 def fake_test_method
   "test_method"
 end
 
-def fake_instance_method
+def fake_special_characters_test_method
+  "test_my_test_method?"
+end
+
+def fake_instance_method(name=fake_test_method)
   @instance_method ||=  stub("InstanceMethod",
                              :source_location => ["path/to/file.rb", 2],
-                             :source => "def #{fake_test_method} \n assert true \n end")
+                             :source => "def #{name} \n assert true \n end")
 end
+

--- a/rubygem/spec/m_spec.rb
+++ b/rubygem/spec/m_spec.rb
@@ -4,6 +4,33 @@ require 'fake_mini_test'
 describe Zeus::M::Runner do
   Runner = Zeus::M::Runner
 
+  context "given a test with a question mark" do
+    before do
+      MiniTest::Unit::TestCase.stub!(:test_suites).and_return [fake_suite_with_special_characters]
+      MiniTest::Unit.stub!(:runner).and_return fake_runner
+    end
+
+    it "escapes the question mark when using line number" do
+      argv = ["path/to/file.rb:2"]
+
+      fake_runner.should_receive(:run).with(["-n", "/(test_my_test_method\\?)/"])
+
+      lambda { Runner.new(argv).run }.should exit_with_code(0)
+    end
+
+    it "escapes the question mark from explicit names" do
+      argv = ["path/to/file.rb", "--name", fake_special_characters_test_method]
+
+      fake_runner.should_receive(:run).with(["-n", "test_my_test_method\\?"])
+
+      lambda { Runner.new(argv).run }.should exit_with_code(0)
+    end
+  end
+end
+
+describe Zeus::M::Runner do
+  Runner = Zeus::M::Runner
+
   before do
     stub_mini_test_methods
   end


### PR DESCRIPTION
When running a test that has a name with any special characters in it (namely ? and other symbols important for regular expressions), the test runner fails to match because the symbols aren't escaped.

Rebase of #341, because I deleted my zeus repo and that PR won't update.
