### PR TITLE
make sure minitest does not install it's exit hook

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -182,6 +182,14 @@ module Zeus
     end
 
     def test_helper
+      # don't let minitest setup another exit hook
+      begin
+        require 'minitest/unit'
+        MiniTest::Unit.class_variable_set("@@installed_at_exit", true)
+      rescue LoadError
+        # noop
+      end
+
       if File.exists?(ROOT_PATH + "/spec/spec_helper.rb")
         require 'spec_helper'
       elsif File.exist?(ROOT_PATH + "/test/minitest_helper.rb")


### PR DESCRIPTION
we run minitest tests directly so we need to make sure that minitest
does not hook into exit by default. This should only happen when
minitest/autorun is loaded but this seems to be the case for the rails
default setup outside of the user controlled test_helper or
minitest_helper
