### PR TITLE
Remove recursion in favor of iteration for lower backtrace depth

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -35,52 +35,68 @@ module Zeus
     end
 
     def go(identifier=:boot)
-      $0 = "zeus slave: #{identifier}"
+      while true
+        boot_step = catch(:boot_step) do
+          run_command = catch(:run_command) do
+            $0 = "zeus slave: #{identifier}"
 
-      setup_dummy_tty!
-      master = setup_master_socket!
-      feature_pipe_r, feature_pipe_w = IO.pipe
+            setup_dummy_tty!
+            master = setup_master_socket!
+            feature_pipe_r, feature_pipe_w = IO.pipe
 
-      # I need to give the master a way to talk to me exclusively
-      local, remote = UNIXSocket.pair(Socket::SOCK_STREAM)
-      master.send_io(remote)
+            # I need to give the master a way to talk to me exclusively
+            local, remote = UNIXSocket.pair(Socket::SOCK_STREAM)
+            master.send_io(remote)
 
-      # Now I need to tell the master about my PID and ID
-      local.write "P:#{Process.pid}:#{identifier}\0"
-      local.send_io(feature_pipe_r)
-      feature_pipe_r.close
+            # Now I need to tell the master about my PID and ID
+            local.write "P:#{Process.pid}:#{identifier}\0"
+            local.send_io(feature_pipe_r)
+            feature_pipe_r.close
 
-      # Now we run the action and report its success/fail status to the master.
-      features = Zeus::LoadTracking.features_loaded_by {
-        run_action(local, identifier, feature_pipe_w)
-      }
+            # Now we run the action and report its success/fail status to the master.
+            features = Zeus::LoadTracking.features_loaded_by {
+              run_action(local, identifier, feature_pipe_w)
+            }
 
-      # the master wants to know about the files that running the action caused us to load.
-      Thread.new { notify_features(feature_pipe_w, features) }
+            # the master wants to know about the files that running the action caused us to load.
+            Thread.new { notify_features(feature_pipe_w, features) }
 
-      # We are now 'connected'. From this point, we may receive requests to fork.
-      children = Set.new
-      loop do
-        messages = local.recv(2**16)
+            # We are now 'connected'. From this point, we may receive requests to fork.
+            children = Set.new
+            while true
+              messages = local.recv(2**16)
 
-        # Reap any child runners or slaves that might have exited in
-        # the meantime. Note that reaping them like this can leave <=1
-        # zombie process per slave around while the slave waits for a
-        # new command.
-        children.each do |pid|
-          children.delete(pid) if Process.waitpid(pid, Process::WNOHANG)
-        end
+              # Reap any child runners or slaves that might have exited in
+              # the meantime. Note that reaping them like this can leave <=1
+              # zombie process per slave around while the slave waits for a
+              # new command.
+              children.each do |pid|
+                children.delete(pid) if Process.waitpid(pid, Process::WNOHANG)
+              end
 
-        messages.split("\0").each do |new_identifier|
-          new_identifier =~ /^(.):(.*)/
-          code, ident = $1, $2
-          pid = nil
-          if code == "S"
-            children << fork { go(ident.to_sym) }
-          else
-            children << fork { command(ident.to_sym, local) }
+              messages.split("\0").each do |new_identifier|
+                new_identifier =~ /^(.):(.*)/
+                code, ident = $1, $2
+                pid = fork
+                if pid
+                  # We're in the parent. Record the child:
+                  children << pid
+                elsif code == "S"
+                  # Child, supposed to start another step:
+                  throw(:boot_step, ident.to_sym)
+                else
+                  # Child, supposed to run a command:
+                  throw(:run_command, [ident.to_sym, local])
+                end
+              end
+            end
+          end
+          if run_command
+            ident, local = run_command
+            command(ident, local)
           end
         end
+        identifier = boot_step
       end
     end
 


### PR DESCRIPTION
Change the structure of Zeus.go to use throw/catch and iteration instead of recursive calls to go in order to boot slaves and commands. This changes the number of backtrace frames occupied by Zeus to be constant, instead of scaling linear with the depth of the slave launching a command.

The result is a backtrace that looks like:

```
ZeroDivisionError: divided by 0        from (irb):1:in `/'
        from (irb):1
        from /Users/asf/foo/dev/lib/dev_plan.rb:70:in `block in <class:FooPlan>'
        from /Users/asf/foo/dev/lib/dev_plan.rb:12:in `instance_eval'
        from /Users/asf/foo/dev/lib/dev_plan.rb:12:in `block in command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:137:in `block in command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:130:in `call'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:130:in `block (2 levels) in wrap'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/class_methods.rb:76:in `call'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/class_methods.rb:76:in `enter'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:117:in `enter'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:129:in `block in wrap'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/core_ext.rb:59:in `fork'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/core_ext.rb:59:in `block (2 levels) in in_lspace'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:124:in `command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:96:in `block in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:39:in `catch'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:39:in `go'
```

Instead of:

```
ZeroDivisionError: divided by 0
        from (irb):1:in `/'
        from (irb):1
        from /Users/asf/foo/dev/lib/dev_plan.rb:70:in `block in <class:FooPlan>'
        from /Users/asf/foo/pay-server/dev/lib/dev_plan.rb:12:in `instance_eval'
        from /Users/asf/foo/dev/lib/dev_plan.rb:12:in `block in command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:126:in `block in command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:130:in `call'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:130:in `block (2 levels) in wrap'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/class_methods.rb:76:in `call'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/class_methods.rb:76:in `enter'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:117:in `enter'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace.rb:129:in `block in wrap'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/core_ext.rb:59:in `fork'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/lspace-0.10/lib/lspace/core_ext.rb:59:in `block (2 levels) in in_lspace'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:113:in `command'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:82:in `block (4 levels) in go'
... 25 levels...
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:75:in `each'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:75:in `block (2 levels) in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:64:in `loop'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:64:in `block in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:38:in `catch'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:38:in `go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:80:in `block (4 levels) in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:80:in `fork'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:80:in `block (3 levels) in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:75:in `each'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:75:in `block (2 levels) in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:64:in `loop'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:64:in `block in go'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:38:in `catch'
        from /Users/asf/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/zeus-0.13.3.0.115/lib/zeus.rb:38:in `go'
```

(Note the `...25 levels...`)

The main benefit of this is aesthetic, and not on the code side (as you can well see in the diff). However, I think it might be worthwhile to not have Zeus cause up to dozens of lines of backtrace material that ends up being useless information in case something goes wrong.

On the other hand, I think a backtrace with O(depth of the command's slave) frames wouldn't be pretty cool, if it could provide some more information on the plan that got you there (which the current zeus backtraces don't do either).

Basically, I'm torn on whether this is the right way to go, but am pretty sure something should be done (-:
