### PR TITLE
Added ENV variable to force test helper

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -190,12 +190,16 @@ module Zeus
         # noop
       end
 
-      if File.exists?(ROOT_PATH + "/spec/spec_helper.rb")
-        require 'spec_helper'
-      elsif File.exist?(ROOT_PATH + "/test/minitest_helper.rb")
-        require 'minitest_helper'
+      if ENV['RAILS_TEST_HELPER']
+        require ENV['RAILS_TEST_HELPER']
       else
-        require 'test_helper'
+        if File.exists?(ROOT_PATH + "/spec/spec_helper.rb")
+          require 'spec_helper'
+        elsif File.exist?(ROOT_PATH + "/test/minitest_helper.rb")
+          require 'minitest_helper'
+        else
+          require 'test_helper'
+        end
       end
     end
 


### PR DESCRIPTION
When the project uses two different test frameworks, for example rspec and test::unit, zeus forced to use rspec in every test, which casued fails.
To fix this, I added env variable to enforce helper that should be used.
