### PR TITLE
Fix fsevents-wrapper settings so it builds on Xcode5

### DIFF
--- a/ext/fsevents/fsevents-wrapper.xcodeproj/project.pbxproj
+++ b/ext/fsevents/fsevents-wrapper.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		82DC010F15C6EE760098E42A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0440;
+				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = "Burke Libbey";
 			};
 			buildConfigurationList = 82DC011215C6EE760098E42A /* Build configuration list for PBXProject "fsevents-wrapper" */;
@@ -170,7 +170,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -191,31 +191,29 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
 		82DC012815C6EE760098E42A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		82DC012915C6EE760098E42A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.7;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This bumps the default SDK to use to 10.8 (but doesn't bump the deploy target version). @burke - I'm not sure what version of OS X you run, but if you run a ~recent version of Xcode, you'll probably want this (-:
