### PR TITLE
Fix version option.

### DIFF
--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -46,6 +46,9 @@ func main() {
 			} else {
 				execManPage("zeus")
 			}
+		case "--version":
+			printVersion()
+			return
 		}
 	}
 	if len(Args) == 0 {
@@ -56,8 +59,8 @@ func main() {
 		execManPage("zeus")
 	} else if Args[0] == "help" {
 		commandSpecificHelp(Args)
-	} else if Args[0] == "version" || Args[0] == "--version" {
-		println("Zeus version " + zeusversion.VERSION)
+	} else if Args[0] == "version" {
+		printVersion()
 	} else if Args[0] == "start" {
 		zeusmaster.Run()
 	} else if Args[0] == "init" {
@@ -170,4 +173,8 @@ func generalHelpRequested(args []string) bool {
 		}
 	}
 	return false
+}
+
+func printVersion() {
+	println("Zeus version " + zeusversion.VERSION)
 }


### PR DESCRIPTION
## Problem

```
zeus --version
```

opens the man page rather than printing the version, even though the code intends to support this option.

This happens because the loop to handle options doesn't check for `--version`, ignores unknown options, and consumes those options.  So, the following [`if len(Args) == 0` condition](https://github.com/burke/zeus/blob/master/go/cmd/zeus/zeus.go#L51) is true, and the man page is opened, before the check for `Args[0] == "--version"`.
## Solution

Check for the version option in the loop with the other options.  Extract the logic to a function to avoid duplication.
