### PR TITLE
Fix gem version lookup

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -13,7 +13,7 @@ require 'zeus'
 
 def gem_is_bundled?(gem)
   gemfile_lock_contents = File.read(ROOT_PATH + "/Gemfile.lock")
-  gemfile_lock_contents.scan(/\b#{gem} \(([^=~><]+?)\)/).flatten.first
+  gemfile_lock_contents.scan(/^\s*#{gem} \(([^=~><]+?)\)/).flatten.first
 end
 
 if version = gem_is_bundled?('method_source')

--- a/rubygem/spec/rails_spec.rb
+++ b/rubygem/spec/rails_spec.rb
@@ -43,5 +43,20 @@ module Zeus
         rails.test_helper
       end
     end
+
+    context "#gem_is_bundled?" do
+      it "returns gem version from Gemfile.lock" do
+        File.stub(:read).and_return("
+GEM
+  remote: https://rubygems.org/
+  specs:
+    exception_notification-rake (0.0.6)
+      exception_notification (~> 3.0.1)
+      rake (>= 0.9.0)
+    rake (10.0.4)
+")
+        gem_is_bundled?('rake').should == '10.0.4'
+      end
+    end
   end
 end


### PR DESCRIPTION
It might happens gem name contains '-rake'. In this case scan by word boundary will find it.

If Gemfile.lock contains

exception_notification-rake (~> 0.0.6)

then rake version will be detected as 0.0.6
