### PR TITLE
Alternate s for zeus start

### DIFF
--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -154,7 +154,7 @@ func commandNotFound(command string) {
 }
 
 func commandSpecificHelp(args []string) {
-	if args[1] == "start" || Args[1] == "s" {
+	if args[1] == "start" || args[1] == "s" {
 		execManPage("zeus-start")
 	} else if args[1] == "init" {
 		execManPage("zeus-init")


### PR DESCRIPTION
I admit, I am the laziest person ever.  I type "zeus start" quite a bit in the terminal and I was wondering why can't I just type "zeus s" and be done with it?  Why am I forced to type 4 more letters?

I kind of guessed on where the code should go, but I'm assuming that I put the "or" statements in the correct places.

Thank you!
