### PR TITLE
Read application.rb as UTF-8 (Invalid byte sequence error)

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -92,7 +92,7 @@ module Zeus
       # Some 'alternative' ORMs such as Mongoid give instructions to switch this require
       # out for a list of railties, not including ActiveRecord.
       # We grep config/application.rb for all requires of rails/all or railties, and require them.
-      rails_components = File.read(APP_PATH + ".rb").
+      rails_components = File.read(APP_PATH + ".rb", :encoding => 'utf-8').
         scan(/^\s*require\s*['"](.*railtie.*|rails\/all)['"]/).flatten
 
       rails_components = ["rails/all"] if rails_components == []


### PR DESCRIPTION
`zeus start` threw me the following error:

```
/Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus/rails.rb:85:in `scan': invalid byte sequence in US-ASCII (ArgumentError)
    from /Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus/rails.rb:85:in `boot'
    from /Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus.rb:166:in `run_action'
    from /Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus.rb:54:in `block in go'
    from /Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus/load_tracking.rb:7:in `features_loaded_by'
    from /Users/mikko/.rvm/gems/ruby-1.9.3-p448/gems/zeus-0.13.3/lib/zeus.rb:53:in `go'
```

Apparently the error was due to the fact that my [application.rb](https://github.com/sharetribe/sharetribe/blob/master/config/application.rb) file is UTF-8 and it contains some localization configs including Chinese, Russian, etc. characters.

Adding `:encofing => 'utf-8' solved the issue.
