### PR TITLE
Explicitly require set

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -8,6 +8,7 @@ if File.exist?(gemfile) && version = File.read(gemfile)[/^    json \((.*)\)/, 1]
 end
 require 'json'
 require 'pty'
+require 'set'
 
 require 'zeus/load_tracking'
 require 'zeus/plan'


### PR DESCRIPTION
This is required, it worked before because zeus relied on bundler loading rails or other things which may require set. Without that we get difficult to debug hangs.
