### PR TITLE
do not double-escape test names

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -226,8 +226,7 @@ module Zeus
         elsif user_specified_name?
           abort_with_no_test_found_by_name unless tests.contains?(@test_name)
 
-          test_names = test_name_to_s
-          ["-n", test_names]
+          ["-n", test_name_to_s]
         else
           []
         end
@@ -254,7 +253,7 @@ module Zeus
       end
 
       def test_name_to_s
-        @test_name.is_a?(Regexp)? "/#{Regexp.escape(@test_name.source)}/" : Regexp.escape(@test_name)
+        @test_name.is_a?(Regexp)? "/#{@test_name.source}/" : @test_name
       end
 
       def user_specified_name?

--- a/rubygem/spec/m_spec.rb
+++ b/rubygem/spec/m_spec.rb
@@ -18,10 +18,10 @@ module Zeus::M
         lambda { Runner.new(argv).run }.should exit_with_code(0)
       end
 
-      it "escapes the question mark from explicit names" do
+      it "does not escape regex on explicit names" do
         argv = ["path/to/file.rb", "--name", fake_special_characters_test_method]
 
-        fake_runner.should_receive(:run).with(["-n", "test_my_test_method\\?"])
+        fake_runner.should_receive(:run).with(["-n", "test_my_test_method?"])
 
         lambda { Runner.new(argv).run }.should exit_with_code(0)
       end


### PR DESCRIPTION
atm zeus turns `-n '/foo.bar/'` into `-n '/foo\.bar/'` which no longer matches 'fooxbar' but just 'foo.bar'

@latortuga
