### PR TITLE
Fix exit to handle boolean return value from Minitest.run

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -198,7 +198,7 @@ module Zeus
         case framework
         when :minitest5
           nerf_test_unit_autorunner
-          exit(Minitest.run(test_arguments).to_i)
+          exit(Minitest.run(test_arguments) ? 0 : 1)
         when :minitest_old
           nerf_test_unit_autorunner
           exit(MiniTest::Unit.runner.run(test_arguments).to_i)


### PR DESCRIPTION
Unlike Minitest::Unit.runner.run which returns an integer code indicating the total number of failed tests, Minitest.run in Minitest 5 simply returns true or false. This fixes Zeus to return 0 to indicate success and 1 to indicate failure (instead of returning the number of failed tests which is not directly accessible through the new Minitest API).

Relates to https://github.com/burke/zeus/issues/475.
