### PR TITLE
Fix Minitest exit hook hack to handle Minitest 5

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -177,7 +177,13 @@ module Zeus
       # don't let minitest setup another exit hook
       begin
         require 'minitest/unit'
-        MiniTest::Unit.class_variable_set("@@installed_at_exit", true)
+        if defined?(Minitest::Runnable)
+          # Minitest 5
+          MiniTest.class_variable_set('@@installed_at_exit', true)
+        elsif defined?(MiniTest)
+          # Old versions of Minitest
+          MiniTest::Unit.class_variable_set("@@installed_at_exit", true)
+        end
       rescue LoadError
         # noop
       end


### PR DESCRIPTION
Extends Minitest exit hook workaround to handle Minitest 5 in addition to previous versions of Minitest: this will prevent tests from running twice under certain circumstances.

Relates to:
https://github.com/burke/zeus/issues/356
https://github.com/burke/zeus/issues/475
