### PR TITLE
Added rbx-2 to Travis Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.0.0
   - 2.1.2
   - 2.1.3
+  - rbx-2
 gemfile: rubygem/Gemfile
 script: make rubygem/lib/zeus/version.rb && cd rubygem && bundle exec rspec spec
 


### PR DESCRIPTION
Zeus claims to be Rubinius-compatible, so it should run its specs against rbx-2 on Travis. The Travis build remains [green](https://travis-ci.org/sshao/zeus/builds/44855195). 
