### PR TITLE
Fix "zeus test"

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -126,12 +126,8 @@ module Zeus
       def parse
         # With no arguments,
         if @argv.empty?
-          # Just shell out to `rake test`.
-          require 'rake'
-          Rake.application.init
-          Rake.application.load_rakefile
-          Rake.application.invoke_task("test")
-          exit
+          @files = []
+          add_file("test")
         else
           parse_options! @argv
 

--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -128,7 +128,9 @@ module Zeus
         if @argv.empty?
           # Just shell out to `rake test`.
           require 'rake'
-          Rake::Task['test'].invoke
+          Rake.application.init
+          Rake.application.load_rakefile
+          Rake.application.invoke_task("test")
           exit
         else
           parse_options! @argv

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -206,9 +206,13 @@ module Zeus
     end
 
     def test(argv=ARGV)
-      if spec_file?(argv) && defined?(RSpec)
+      # if there are two test frameworks and one of them is RSpec,
+      # then "zeus test/rspec/testrb" without arguments runs the
+      # RSpec suite by default.
+      if (argv.empty? || spec_file?(argv)) && defined?(RSpec)
         # disable autorun in case the user left it in spec_helper.rb
         RSpec::Core::Runner.disable_autorun!
+        argv = ["spec"] if argv.empty?
         exit RSpec::Core::Runner.run(argv)
       else
         Zeus::M.run(argv)


### PR DESCRIPTION
Attempt to fix currently failing `zeus test (rspec, testrb)` command (#213):

1. `Rake::Task['test']` fails to invoke the `test` task. To fix this, use `Rake::Application` to load the app's Rakefile, and then invoke the `test` task.
2. After fixing the above, `zeus test` on an app using RSpec still does not work as expected because the test command falls through to `Zeus::M`. To fix, invoke the RSpec runner on the following condition: 

  1. no arguments are passed in `zeus test`, and
  2. `defined?(RSpec) == true`

  This means that if RSpec and *other* testing frameworks are in use (#149), `zeus test` will run the RSpec suite by default. To run another framework's suites, the user will have to run `zeus test <path_to_other_suite>`. Hopefully this is reasonable.