### PR TITLE
inotify-wrapper: don't hang on EOF [fix #501]

### DIFF
--- a/rubygem/ext/inotify-wrapper/inotify-wrapper.cpp
+++ b/rubygem/ext/inotify-wrapper/inotify-wrapper.cpp
@@ -102,6 +102,7 @@ void go()
     if (retval == -1) {
       // perror("select");
     } else if (retval) {
+      if(feof(stdin)) break;
       if (FD_ISSET(0, &rfds))           handleStdin();
       if (FD_ISSET(_inotify_fd, &rfds)) handleInotify();
     }


### PR DESCRIPTION
on EOF select() says stdin is ready, fgets fails and so inotify-wrapper loops
forever