### PR TITLE
Remove hacks around Minitest internals, make peace with Minitest.autorun

### DIFF
--- a/rubygem/Gemfile
+++ b/rubygem/Gemfile
@@ -3,5 +3,9 @@ source 'https://rubygems.org'
 # NOTE: Avoid putting development deps in gemspec
 gemspec development_group: :gem_build_tools
 
-gem 'rspec', '~> 3.1', groups: [:test, :development]
+group :test, :development do
+  gem 'rspec', '~> 3.1'
+  gem 'pry', '~> 0.10'
+end
+
 gem 'rake', group: :gem_build_tools

--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -194,12 +194,10 @@ module Zeus
 
         # directly run the tests from here and exit with the status of the tests passing or failing
         case framework
-        when :minitest5
-          nerf_test_unit_autorunner
-          exit(Minitest.run(test_arguments) ? 0 : 1)
-        when :minitest_old
-          nerf_test_unit_autorunner
-          exit(MiniTest::Unit.runner.run(test_arguments).to_i)
+        when :minitest5, :minitest_old
+          require 'minitest/autorun'
+          ARGV.replace(test_arguments)
+          exit
         when :testunit1, :testunit2
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else
@@ -345,13 +343,6 @@ module Zeus
             end
             collection
           end
-        end
-      end
-
-      def nerf_test_unit_autorunner
-        return unless defined?(Test::Unit::Runner)
-        if Test::Unit::Runner.class_variable_get("@@installed_at_exit")
-          Test::Unit::Runner.class_variable_set("@@stop_auto_run", true)
         end
       end
 

--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -195,7 +195,6 @@ module Zeus
         # directly run the tests from here and exit with the status of the tests passing or failing
         case framework
         when :minitest5, :minitest_old
-          require 'minitest/autorun'
           ARGV.replace(test_arguments)
           exit
         when :testunit1, :testunit2

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -196,15 +196,11 @@ module Zeus
       # then "zeus test/rspec/testrb" without arguments runs the
       # RSpec suite by default.
       if using_rspec?(argv)
-        # disable autorun in case the user left it in spec_helper.rb
-        RSpec::Core::Runner.disable_autorun!
-        argv = ["spec"] if argv.empty?
-        exit RSpec::Core::Runner.run(argv)
-      elsif using_minitest?
-        require 'minitest/autorun'
-        Zeus::M.run(argv)
+        ARGV.replace(argv)
+        RSpec::Core::Runner.invoke
       else
-        # old Test::Unit
+        require 'minitest/autorun' if using_minitest?
+        # Minitest and old Test::Unit
         Zeus::M.run(argv)
       end
     end
@@ -216,7 +212,7 @@ module Zeus
     end
 
     def using_minitest?
-      defined?(MiniTest) || defined?(Minitest)
+      defined?(:MiniTest) || defined?(:Minitest)
     end
 
     SPEC_DIR_REGEXP = %r"(^|/)spec"

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -195,22 +195,34 @@ module Zeus
       # if there are two test frameworks and one of them is RSpec,
       # then "zeus test/rspec/testrb" without arguments runs the
       # RSpec suite by default.
-      if (argv.empty? || spec_file?(argv)) && defined?(RSpec)
+      if using_rspec?(argv)
         # disable autorun in case the user left it in spec_helper.rb
         RSpec::Core::Runner.disable_autorun!
         argv = ["spec"] if argv.empty?
         exit RSpec::Core::Runner.run(argv)
+      elsif using_minitest?
+        require 'minitest/autorun'
+        Zeus::M.run(argv)
       else
+        # old Test::Unit
         Zeus::M.run(argv)
       end
     end
 
     private
 
+    def using_rspec?(argv)
+      defined?(RSpec) && (argv.empty? || spec_file?(argv))
+    end
+
+    def using_minitest?
+      defined?(MiniTest) || defined?(Minitest)
+    end
+
     SPEC_DIR_REGEXP = %r"(^|/)spec"
     SPEC_FILE_REGEXP = /.+_spec\.rb$/
 
-    def spec_file? argv
+    def spec_file?(argv)
       argv.any? do |arg|
         arg.match(Regexp.union(SPEC_DIR_REGEXP, SPEC_FILE_REGEXP))
       end

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -174,20 +174,6 @@ module Zeus
     end
 
     def test_helper
-      # don't let minitest setup another exit hook
-      begin
-        require 'minitest/unit'
-        if defined?(Minitest::Runnable)
-          # Minitest 5
-          MiniTest.class_variable_set('@@installed_at_exit', true)
-        elsif defined?(MiniTest)
-          # Old versions of Minitest
-          MiniTest::Unit.class_variable_set("@@installed_at_exit", true)
-        end
-      rescue LoadError
-        # noop
-      end
-
       if ENV['RAILS_TEST_HELPER']
         require ENV['RAILS_TEST_HELPER']
       else

--- a/rubygem/spec/fake_mini_test.rb
+++ b/rubygem/spec/fake_mini_test.rb
@@ -1,20 +1,31 @@
-module MiniTest
-  module Unit
+module Minitest
+  class Runnable
+  end
+end
+
+class MiniTest
+  class Unit
     class TestCase
     end
   end
 end
 
 def stub_mini_test_methods
-  allow(MiniTest::Unit::TestCase).to receive(:test_suites).and_return([fake_suite])
-  allow(MiniTest::Unit).to receive(:runner).and_return(fake_runner)
+  allow(Minitest::Runnable).to receive(:runnables).and_return([fake_mt5_suite])
+  allow(MiniTest::Unit::TestCase).to receive(:test_suite).and_return([fake_mt_old_suite])
 end
 
 def fake_runner
- @runner ||= double("Runner", :run => 0)
+  @runner ||= double("Runner", :run => 0)
 end
 
-def fake_suite
+def fake_mt5_suite
+  @suite ||= double("TestSuite",
+                  :runnable_methods => [test_method],
+                  :instance_method => fake_instance_method(test_method))
+end
+
+def fake_mt_old_suite
   @suite ||= double("TestSuite",
                   :test_methods => [test_method],
                   :instance_method => fake_instance_method(test_method))

--- a/rubygem/spec/m_spec.rb
+++ b/rubygem/spec/m_spec.rb
@@ -15,17 +15,16 @@ module Zeus::M
       it "escapes the question mark when using line number" do
         argv = ["path/to/file.rb:2"]
 
-        expect(fake_runner).to receive(:run).with(["-n", "/(test_my_test_method\\?)/"])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+        expect(ARGV).to eq(["-n", "/(test_my_test_method\\?)/"])
       end
 
       it "does not escape regex on explicit names" do
         argv = ["path/to/file.rb", "--name", fake_special_characters_test_method]
 
-        allow(fake_runner).to receive(:run).with(["-n", "test_my_test_method?"])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+
+        expect(ARGV).to eq(["-n", "test_my_test_method?"])
       end
     end
 
@@ -33,9 +32,9 @@ module Zeus::M
       it "runs the test" do
         argv = ["path/to/file.rb"]
 
-        allow(fake_runner).to receive(:run).with([])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+
+        expect(ARGV).to eq([])
       end
     end
 
@@ -44,7 +43,6 @@ module Zeus::M
         argv = ["path/to/file.rb:100"]
 
         expect(STDERR).to receive(:write).with(/No tests found on line 100/)
-        expect(fake_runner).to_not receive :run
 
         expect(lambda { Runner.new(argv).run }).to_not exit_with_code(0)
       end
@@ -52,9 +50,8 @@ module Zeus::M
       it "runs the test if the correct line number is given" do
         argv = ["path/to/file.rb:2"]
 
-        expect(fake_runner).to receive(:run).with(["-n", "/(#{fake_test_method})/"])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+        expect(ARGV).to eq(["-n", "/(#{fake_test_method})/"])
       end
     end
 
@@ -62,17 +59,15 @@ module Zeus::M
       it "runs the specified tests when using a pattern in --name option" do
         argv = ["path/to/file.rb", "--name", "/#{fake_test_method}/"]
 
-        expect(fake_runner).to receive(:run).with(["-n", "/#{fake_test_method}/"])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+        expect(ARGV).to eq(["-n", "/#{fake_test_method}/"])
       end
 
       it "runs the specified tests when using a pattern in -n option" do
         argv = ["path/to/file.rb", "-n", "/method/"]
 
-        expect(fake_runner).to receive(:run).with(["-n", "/method/"])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+        expect(ARGV).to eq(["-n", "/method/"])
       end
 
       it "aborts if no test matches the given pattern" do
@@ -87,9 +82,8 @@ module Zeus::M
       it "runs the specified tests when using a name (no pattern)" do
         argv = ["path/to/file.rb", "-n", "#{fake_test_method}"]
 
-        expect(fake_runner).to receive(:run).with(["-n", fake_test_method])
-
         expect(lambda { Runner.new(argv).run }).to exit_with_code(0)
+        expect(ARGV).to eq(["-n", fake_test_method])
       end
 
       it "aborts if no test matches the given test name" do

--- a/rubygem/spec/spec_helper.rb
+++ b/rubygem/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'zeus/rails'
+require 'pry'
 
 RSpec::Matchers.define :exit_with_code do |exp_code|
   actual = nil


### PR DESCRIPTION
We want to run Minitest via `Minitest.run`. Rails requires `'minitest/autorun'` when requiring `'rails/test_help'` which means invoking `Minitest.run(our_arguments)` will cause tests to get run twice, once with our arguments and once with ARGV via autorun.

Instead of trying to hack around Minitest class variables and prevent autorun from working, we'll stop fighting it and let Minitest run our desired tests by replacing ARGV with our desired test arguments and letting autorun invoke the tests when the child processes exit. This is still a bit of an introspection of Minitest's API because we're mangling ARGV but Minitest has executed with ARGV explicitly in autorun for at least two major releases so we'll go with it for now.

Previously discussed [here](https://github.com/burke/zeus/pull/348/files#r6562957).

@zenspider I welcome any feedback on this mechanism for hooking into `autorun`. I'm trying to balance working out of the box with standard Rails `test_helper` against mucking with Minitest's internals and I'm definitely open to other ways of passing proper arguments into `Minitest.run`.

@blowmage I would also appreciate your thoughts on this.