### PR TITLE
Use bundler/setup instead of custom loading code

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -1,11 +1,6 @@
 # encoding: utf-8
 require 'socket'
 
-# load exact json version from Gemfile.lock to avoid conflicts
-gemfile = "#{ENV["BUNDLE_GEMFILE"] || "Gemfile"}.lock"
-if File.exist?(gemfile) && version = File.read(gemfile)[/^    json \((.*)\)/, 1]
-  gem 'json', version
-end
 require 'json'
 require 'pty'
 require 'set'

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -1,3 +1,8 @@
+# Load proper Gemfile.lock and activate all the gems. If there's a conflict
+# between a gem version that has already been loaded and the one specified in
+# the Gemfile.lock, raise an error.
+require 'bundler/setup'
+
 def find_rails_path(root_path)
   paths = %w(spec/dummy test/dummy .)
   paths.find { |path| File.exists?(File.expand_path(path, root_path)) }
@@ -10,16 +15,7 @@ BOOT_PATH = File.expand_path('config/boot',  RAILS_PATH)
 APP_PATH  = File.expand_path('config/application',  RAILS_PATH) unless defined? APP_PATH
 
 require 'zeus'
-
-def gem_is_bundled?(gem)
-  gemfile_lock_contents = File.read(ROOT_PATH + "/Gemfile.lock")
-  gemfile_lock_contents.scan(/^\s*#{gem} \(([^=~><]+?)\)/).flatten.first
-end
-
-if version = gem_is_bundled?('method_source')
-  gem 'method_source', version
-end
-
+require 'method_source'
 require 'zeus/m'
 
 module Zeus
@@ -31,9 +27,6 @@ module Zeus
     end
 
     def _monkeypatch_rake
-      if version = gem_is_bundled?('rake')
-        gem 'rake', version
-      end
       require 'rake/testtask'
       Rake::TestTask.class_eval {
 

--- a/rubygem/spec/rails_spec.rb
+++ b/rubygem/spec/rails_spec.rb
@@ -61,23 +61,6 @@ module Zeus
       end
     end
 
-    describe "#gem_is_bundled?" do
-      context "for a bundled gem" do
-        it "returns the bundled gem's version" do
-          allow(File).to receive(:read).and_return("
-  GEM
-    remote: https://rubygems.org/
-    specs:
-      exception_notification-rake (0.0.6)
-        exception_notification (~> 3.0.1)
-        rake (>= 0.9.0)
-      rake (10.0.4)
-  ")
-          expect(gem_is_bundled?('rake')).to eq '10.0.4'
-        end
-      end
-    end
-
     describe "#test" do
       def expect_minitest_autorun
         # Zeus::Rails#test_helper will require minitest/unit by default.


### PR DESCRIPTION
I'm not sure if this has been discussed already. Using the `require
'bundle/setup'` directive made the gem activation errors a bit more
predictable for me during some preliminary runs. It's quite possible
that I might've missed something here.

Adding "require 'bundler/setup'" to a file will add the bundled gems to
the load path. This is a much safer way to load gems instead of using
`gem <gemname>, <version>` where version is parsed from the Gemfile.

Loading 'bundler/setup.rb' does the following things:

1. Cleans load path; one of it's function is to removing system gems
   from the load path.
2. Loads the gem specs from Gemfile.lock
3. Sets up the following path variables:
   BUNDLE_BIN_PATH
   BUNDLE_GEMFILE: location of the Gemfile
   PATH: Appends the location of `bundle` executable for the current
         Ruby version to the PATH.
   RUBYOPT
   RUBYLIB
3. Activate the loaded Gem file specs. This is where the command would
   throw an exception if there's a conflict in the case where a
   different version of a particular gem in the Gemfile.lock has already
   been loaded.

This makes the process more transparent. After this change, the error
notifications would be split into two cases: 1. Before the connection
between Go daemon and the Ruby process gets established and 2. After the
connection gets setup.

In the case of 1, the error messages still won't show up in the UI and
`dtruss` or `strace` is the only way to figure out the error. However,
in the case of 2, any error in the loading would cause the zeus Go
process to throw an error (prompts turning red) and running any of the
commands would result in a backtrace.