### PR TITLE
Simplify load tracking logic

### DIFF
--- a/rubygem/spec/load_tracking_spec.rb
+++ b/rubygem/spec/load_tracking_spec.rb
@@ -28,5 +28,15 @@ describe "Zeus::LoadTracking" do
         expect($untracked_features).to include(__dir__ + "/load_tracking_spec.rb")
       end
     end
+
+    context '.features_loaded_by' do
+      it 'returns list of new files loaded when block executes' do
+        new_files = Zeus::LoadTracking.features_loaded_by do
+          $untracked_features << "an_untracked_feature.rb"
+        end
+
+        expect(new_files).to eq(["an_untracked_feature.rb"])
+      end
+    end
   end
 end

--- a/rubygem/spec/load_tracking_spec.rb
+++ b/rubygem/spec/load_tracking_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "Zeus::LoadTracking" do
+  let(:test_filename) { __FILE__ }
+  let(:test_dirname)  { File.dirname(test_filename) }
+
+  describe '.add_feature' do
+    context 'already in load path' do
+      before do
+        # add the dir path of the tempfile to LOAD_PATH
+        $LOAD_PATH  << test_dirname
+      end
+
+      after { $LOAD_PATH.delete test_dirname }
+
+
+      it 'adds full filepath to $untracked_features' do
+        Zeus::LoadTracking.add_feature(test_filename)
+
+        expect($untracked_features).to include(__dir__ + "/load_tracking_spec.rb")
+      end
+    end
+
+    context 'not in load path' do
+      it 'adds full filepath to $untracked_features' do
+        Zeus::LoadTracking.add_feature(test_filename)
+
+        expect($untracked_features).to include(__dir__ + "/load_tracking_spec.rb")
+      end
+    end
+  end
+end

--- a/rubygem/spec/load_tracking_spec.rb
+++ b/rubygem/spec/load_tracking_spec.rb
@@ -13,7 +13,6 @@ describe "Zeus::LoadTracking" do
 
       after { $LOAD_PATH.delete test_dirname }
 
-
       it 'adds full filepath to $untracked_features' do
         Zeus::LoadTracking.add_feature(test_filename)
 


### PR DESCRIPTION
1. Check the file if it exists in the `LOAD_PATH` before checking if it
exists locally. If it's in the load path, use that path. If not, check for
it's existence locally.

2. We expand the file path first, which simplifies the checking of the
file's existence in the `LOAD_PATH` or on the file system.


Add some specs for methods in `Zeus::LoadTracking` module.