### PR TITLE
Make SlaveNode State access threadsafe

### DIFF
--- a/go/statuschart/stdout.go
+++ b/go/statuschart/stdout.go
@@ -1,8 +1,9 @@
 package statuschart
 
 import (
-	"github.com/burke/zeus/go/processtree"
 	"strings"
+
+	"github.com/burke/zeus/go/processtree"
 )
 
 func stdoutStart(tree *processtree.ProcessTree, done, quit chan bool) {

--- a/go/statuschart/stdout.go
+++ b/go/statuschart/stdout.go
@@ -35,7 +35,7 @@ func collectCommands(commands []*processtree.CommandNode, desiredState string) [
 	desiredCommands := make([]*processtree.CommandNode, 0)
 
 	for _, command := range commands {
-		if command.Parent.State == desiredState {
+		if command.Parent.State() == desiredState {
 			desiredCommands = append(desiredCommands, command)
 		}
 	}
@@ -76,7 +76,7 @@ func (s *StatusChart) logCommands() {
 
 func (s *StatusChart) logSubtree(node *processtree.SlaveNode) {
 	log := theChart.directLogger
-	printStateInfo("", node.Name, node.State, true, false)
+	printStateInfo("", node.Name, node.State(), true, false)
 
 	if len(node.Slaves) > 0 {
 		log.ColorizedSansNl("{reset}(")

--- a/go/statuschart/tty.go
+++ b/go/statuschart/tty.go
@@ -101,7 +101,7 @@ func (s *StatusChart) lengthOfOutput() int {
 
 func (s *StatusChart) drawCommands() {
 	for _, command := range s.Commands {
-		state := command.Parent.State
+		state := command.Parent.State()
 
 		alia := strings.Join(command.Aliases, ", ")
 		var aliasPart string
@@ -125,7 +125,7 @@ func (s *StatusChart) drawCommands() {
 }
 
 func (s *StatusChart) drawSubtree(node *processtree.SlaveNode, myIndentation, childIndentation string) {
-	printStateInfo(myIndentation, node.Name, node.State, false, true)
+	printStateInfo(myIndentation, node.Name, node.State(), false, true)
 
 	for i, slave := range node.Slaves {
 		if i == len(node.Slaves)-1 {

--- a/go/statuschart/tty.go
+++ b/go/statuschart/tty.go
@@ -2,12 +2,14 @@ package statuschart
 
 import (
 	"fmt"
-	"github.com/burke/ttyutils"
-	slog "github.com/burke/zeus/go/shinylog"
 	"strings"
 
-	"github.com/burke/zeus/go/processtree"
+	"github.com/burke/ttyutils"
+	slog "github.com/burke/zeus/go/shinylog"
+
 	"os"
+
+	"github.com/burke/zeus/go/processtree"
 )
 
 const (


### PR DESCRIPTION
Currently requestRestart accesses the State attribute of the SlaveNode's Slaves without holding a mutex. This PR makes state a private attribute with a public accessor that automatically locks before reading.

In the process I removed the `stateChanged` Cond which appears to be left over from an old version of the code:
https://github.com/burke/zeus/blob/e20fb4ae6a510ec2c0444d991f4ae12db4111212/go/zeusmaster/slavenode.go

Do you have a standard test plan for changes to the Zeus codebase? I'm happy to try merging this into the Stripe fork first and running it here if that's the best approach but I think it'd be nice to upstream.

cc @ptarjan