### PR TITLE
Fix race in transition from UNBOOTED to BOOTING states

### DIFF
--- a/go/messages/messages.go
+++ b/go/messages/messages.go
@@ -49,6 +49,10 @@ func CreateSpawnCommandMessage(identifier string) string {
 	return "C:" + identifier
 }
 
+func CreateStartBootCommandMessage() string {
+	return "B:"
+}
+
 func ParseClientCommandRequestMessage(msg string) (int, int, string, error) {
 	parts := strings.SplitN(msg, ":", 4)
 	if parts[0] != "T" {


### PR DESCRIPTION
Zeus currently ignores restart messages when the slave process is in the UNBOOTED state. If the slave process starts loading ruby files, then one of those files changes and then Zeus completes the transition to the BOOTING state, the changes won't trigger a restart. Instead, Zeus should send a message to the slave process confirming that it should start booting.