### PR TITLE
End-to-end integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
-# Not using to test compilation of go component of project because it requires
-# xcodebuild which is not available in the ubuntu environment travis-ci
-# provides.
-language: ruby
-bundler_args: --without development
-rvm:
-  - 2.0.0-p647
-  - 2.1.7
-  - 2.2.3
-  - rbx-2
-gemfile: rubygem/Gemfile
-script: make rubygem/lib/zeus/version.rb && cd rubygem && bundle install --without development && bin/rspec spec
-
-# use new Travis AUFS containers
-sudo: false
+language: go
+go:
+  - 1.5
+env:
+  - USE_RUBY=2.0.0-p647
+  - USE_RUBY=2.1.7
+  - USE_RUBY=2.2.3
+before_install:
+  - rvm use $USE_RUBY --install --fuzzy
+install:
+  - make dev_bootstrap
+  - make rubygem/lib/zeus/version.rb
+script:
+  - make test-go
+  - make build-linux
+  - make rubygem/lib/zeus/version.rb && cd rubygem && bundle install --without development && bin/rspec spec

--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"syscall"
 
+	"time"
+
 	"github.com/burke/zeus/go/config"
 	"github.com/burke/zeus/go/restarter"
 	slog "github.com/burke/zeus/go/shinylog"
 	"github.com/burke/zeus/go/zeusclient"
 	"github.com/burke/zeus/go/zeusmaster"
 	"github.com/burke/zeus/go/zeusversion"
-	"time"
 )
 
 var color bool = true
@@ -74,7 +75,7 @@ func main() {
 	} else if Args[0] == "version" {
 		printVersion()
 	} else if Args[0] == "start" {
-		zeusmaster.Run()
+		os.Exit(zeusmaster.Run())
 	} else if Args[0] == "init" {
 		zeusInit()
 	} else if Args[0] == "commands" {
@@ -83,8 +84,7 @@ func main() {
 		tree := config.BuildProcessTree()
 		for _, name := range tree.AllCommandsAndAliases() {
 			if Args[0] == name {
-				zeusclient.Run()
-				return
+				os.Exit(zeusclient.Run())
 			}
 		}
 

--- a/go/filemonitor/filemonitor.go
+++ b/go/filemonitor/filemonitor.go
@@ -61,10 +61,16 @@ func start(filesChanged chan string, done, quit chan bool) {
 
 func executablePath() []string {
 	port := os.Getenv("ZEUS_NETWORK_FILE_MONITOR_PORT")
+	binary := os.Getenv("ZEUS_LISTENER_BINARY")
+
 	if len(port) > 0 {
+		if binary == "" {
+			binary = "ext/file-listener/file-listener"
+		}
+
 		gemRoot := path.Dir(path.Dir(os.Args[0]))
-		return []string{path.Join(gemRoot, "ext/file-listener/file-listener"), port}
-	} else {
+		return []string{path.Join(gemRoot, binary), port}
+	} else if binary == "" {
 		switch runtime.GOOS {
 		case "darwin":
 			return []string{path.Join(path.Dir(os.Args[0]), "fsevents-wrapper")}
@@ -72,7 +78,10 @@ func executablePath() []string {
 			gemRoot := path.Dir(path.Dir(os.Args[0]))
 			return []string{path.Join(gemRoot, "ext/inotify-wrapper/inotify-wrapper")}
 		}
+	} else {
+		return []string{binary}
 	}
+
 	terminate("Unsupported OS")
 	return []string{}
 }

--- a/go/unixsocket/unixsocket.go
+++ b/go/unixsocket/unixsocket.go
@@ -80,6 +80,13 @@ func init() {
 	}
 }
 
+// SetZeusSockName sets the socket name used for zeus clients.
+// It is primarily exposed for testing purpose and is not safe to
+// modify after Zeus has started.
+func SetZeusSockName(n string) {
+	sockName = n
+}
+
 func ZeusSockName() string {
 	return sockName
 }

--- a/go/zeusclient/zeusclient.go
+++ b/go/zeusclient/zeusclient.go
@@ -23,14 +23,10 @@ const (
 	sigTstp = 26
 )
 
-func Run() {
-	os.Exit(doRun())
-}
-
 // man signal | grep 'terminate process' | awk '{print $2}' | xargs -I '{}' echo -n "syscall.{}, "
 var terminatingSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGPIPE, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGXCPU, syscall.SIGXFSZ, syscall.SIGVTALRM, syscall.SIGPROF, syscall.SIGUSR1, syscall.SIGUSR2}
 
-func doRun() int {
+func Run() int {
 	if os.Getenv("RAILS_ENV") != "" {
 		println("Warning: Specifying a Rails environment via RAILS_ENV has no effect for commands run with zeus.")
 		println("As a safety precaution to protect you from nuking your development database,")

--- a/go/zeusmaster/zeusmaster.go
+++ b/go/zeusmaster/zeusmaster.go
@@ -20,11 +20,7 @@ import (
 // Leaving out SIGPIPE as that is a signal the master receives if a client process is killed.
 var terminatingSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGXCPU, syscall.SIGXFSZ, syscall.SIGVTALRM, syscall.SIGPROF, syscall.SIGUSR1, syscall.SIGUSR2}
 
-func Run() {
-	os.Exit(doRun())
-}
-
-func doRun() int {
+func Run() int {
 	slog.Colorized("{green}Starting {yellow}Z{red}e{blue}u{magenta}s{green} server v" + zeusversion.VERSION)
 
 	zerror.Init()

--- a/go/zeusmaster/zeusmaster_test.go
+++ b/go/zeusmaster/zeusmaster_test.go
@@ -1,0 +1,267 @@
+package zeusmaster_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/burke/zeus/go/config"
+	slog "github.com/burke/zeus/go/shinylog"
+	"github.com/burke/zeus/go/unixsocket"
+	"github.com/burke/zeus/go/zeusmaster"
+)
+
+var testFiles = map[string]string{
+	"zeus.json": `
+{
+  "command": "ruby -r./custom_plan -eZeus.go",
+  "plan": {
+    "boot": {
+      "data": {
+        "data_srv": {}
+      },
+      "code": {
+        "code_srv": {}
+      },
+      "cmd_srv": []
+    }
+  }
+}
+`,
+	"custom_plan.rb": `
+$LOAD_PATH.unshift(File.readlink('./lib'))
+require 'zeus'
+
+class CustomPlan < Zeus::Plan
+  def self.command(name, &block)
+    define_method(name) do
+      redirect_log(name)
+      begin
+        self.instance_eval(&block)
+      rescue => e
+        STDERR.puts "#{name} terminated with exception: #{e.message}"
+        STDERR.puts e.backtrace.map {|line| " #{line}"}
+        raise
+      end
+    end
+  end
+
+  command :boot do
+    redirect_log('boot')
+    require_relative 'srv'
+  end
+
+  command :data do
+    redirect_log('data')
+    require_relative 'data'
+  end
+
+  command :code do
+    redirect_log('code')
+    require_relative 'code'
+  end
+
+  command :cmd_srv do
+    redirect_log('cmd_srv')
+    serve('cmd.sock')
+  end
+
+  command :data_srv do
+    redirect_log('data_srv')
+    serve('data.sock')
+  end
+
+  command :code_srv do
+    redirect_log('code_srv')
+    serve('code.sock')
+  end
+
+  def redirect_log(cmd)
+    log_file = File.open("zeus_test_#{cmd}.log", 'a')
+    log_file.sync = true
+    STDOUT.reopen(log_file)
+    STDERR.reopen(log_file)
+    STDOUT.sync = STDERR.sync = true
+  end
+end
+
+Zeus.plan = CustomPlan.new
+`,
+	"data.rb": `
+require 'yaml'
+$response = YAML::load_file('data.yaml')['response']
+`,
+	"data.yaml": `
+response: YAML the Camel is a Mammal with Enamel
+`,
+	"other-data.yaml": `
+response: Hi
+`,
+	"code.rb": `
+$response = "Hello, world!"
+`,
+	"other-code.rb": `
+$response = "there!"
+`,
+	"srv.rb": `
+$response = "pong"
+
+def serve(sock_path)
+  sock = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM, 0)
+  sock.connect(Socket.pack_sockaddr_un(sock_path))
+
+  b = sock.send($response, 0)
+  puts "Wrote #{b} bytes to #{sock_path}"
+end
+`,
+}
+
+func writeTestFiles(dir string) error {
+	for name, contents := range testFiles {
+		if err := ioutil.WriteFile(path.Join(dir, name), []byte(contents), 0644); err != nil {
+			return fmt.Errorf("error writing %s: %v", name, err)
+		}
+	}
+
+	gempath := os.Getenv("ZEUS_TEST_GEMPATH")
+	if gempath == "" {
+		var err error
+		gempath, err = filepath.Abs("rubygem")
+		if err != nil {
+			return fmt.Errorf("error finding gempath: %v", err)
+		}
+	}
+
+	if err := os.Symlink(filepath.Join(gempath, "lib"), filepath.Join(dir, "lib")); err != nil {
+		return fmt.Errorf("error linking zeus gem: %v", err)
+	}
+
+	return nil
+}
+
+func enableTracing() {
+	slog.SetTraceLogger(slog.NewTraceLogger(os.Stderr))
+}
+
+func TestZeusBoots(t *testing.T) {
+	if os.Getenv("ZEUS_LISTENER_BINARY") == "" {
+		t.Fatal("Missing ZEUS_LISTENER_BINARY env var")
+	}
+
+	dir, err := ioutil.TempDir("", "zeus_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := writeTestFiles(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	config.ConfigFile = filepath.Join(dir, "zeus.json")
+	unixsocket.SetZeusSockName(filepath.Join(dir, ".zeus.sock"))
+
+	connections := map[string]*net.UnixConn{
+		"cmd":  nil,
+		"data": nil,
+		"code": nil,
+	}
+
+	for name := range connections {
+		sockName := filepath.Join(dir, fmt.Sprintf("%s.sock", name))
+
+		c, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
+			Name: sockName, Net: "unixgram",
+		})
+		if err != nil {
+			t.Fatalf("Error opening %q socket: %v", sockName, err)
+		}
+		defer c.Close()
+
+		connections[name] = c
+	}
+
+	me, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: Find a way to redirect stdout so we can look for crashed
+	// processes.
+	enableTracing()
+	zexit := make(chan int)
+	go func() {
+		zexit <- zeusmaster.Run()
+	}()
+
+	expects := map[string]string{
+		// TODO: Use the zeusclient to spawn a command to test
+		// that path.
+		// "cmd":  "pong",
+		"data": "YAML the Camel is a Mammal with Enamel",
+		"code": "Hello, world!",
+	}
+
+	for name, want := range expects {
+		if err := readAndCompare(connections[name], want); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+
+	// TODO: It appears the filewatcher takes some time to initialize
+	// so we need to wait for it to propagate before changing things.
+	// Even then there appears to be a bad enough race somewhere that
+	// we get flaky tests if we change more than one file.
+	time.Sleep(1 * time.Second)
+
+	for _, f := range []string{"code.rb" /*, "data.yaml"*/} {
+		from := filepath.Join(dir, fmt.Sprintf("other-%s", f))
+		to := filepath.Join(dir, f)
+		if err := os.Rename(from, to); err != nil {
+			t.Fatalf("Error renaming %s: %v", f, err)
+		}
+	}
+
+	expects = map[string]string{
+		// "data": "Hi",
+		"code": "there!",
+	}
+
+	for name, want := range expects {
+		if err := readAndCompare(connections[name], want); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+
+	// The zeusmaster catches the interrupt and exits gracefully
+	me.Signal(os.Interrupt)
+	if code := <-zexit; code != 0 {
+		t.Fatalf("Zeus exited with %d", code)
+	}
+}
+
+func readAndCompare(conn *net.UnixConn, want string) error {
+	buf := make([]byte, 128)
+
+	// File system events can take a long time to propagate
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	if _, _, err := conn.ReadFrom(buf); err != nil {
+		return err
+	}
+	if have := string(bytes.Trim(buf, "\x00")); have != want {
+		return fmt.Errorf("expected %q, got %q", want, have)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds an end-to-end integration test that:
* Boots Zeus with a tree of multiple commands.
* Ensures that commands boot up.
* Ensures that commands reload when ruby or yaml dependencies change.

The test is currently quite coarse and doesn't introspect much of what Zeus is doing. The goal is to have at least a basic sanity check before writing more detailed unit tests.

I was not able to get rubinius working inside of the Travis golang VM so I've dropped that from the build matrix but retained the other MRI ruby versions.