### PR TITLE
Vendor dependencies with govendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ fmt:
 	find . -name '*.go' | xargs -t -I@ go fmt @
 
 test-go: go/zeusversion/zeusversion.go $(TEST_LISTENER_DEP)
-	ZEUS_LISTENER_BINARY=$(realpath $(TEST_LISTENER_DEP)) ZEUS_TEST_GEMPATH=$(GEMPATH) go test ./...
+	ZEUS_LISTENER_BINARY=$(realpath $(TEST_LISTENER_DEP)) ZEUS_TEST_GEMPATH=$(GEMPATH) GO15VENDOREXPERIMENT=1 govendor test +local
 
 man/build: Gemfile.lock
 	cd man && ../bin/rake
@@ -117,14 +117,14 @@ ext/inotify-wrapper/inotify-wrapper: ext/inotify-wrapper/inotify-wrapper.o
 build/zeus-%: go/zeusversion/zeusversion.go compileBinaries
 	@:
 compileBinaries:
-	gox -osarch="linux/386 linux/amd64 darwin/amd64" \
+	GO15VENDOREXPERIMENT=1 gox -osarch="linux/386 linux/amd64 darwin/amd64" \
 		-output="build/zeus-{{.OS}}-{{.Arch}}" \
 		$(PACKAGE)/go/cmd/zeus
 
 build-linux: go/zeusversion/zeusversion.go compileLinuxBinaries
 	@:
 compileLinuxBinaries:
-	gox -osarch="linux/386 linux/amd64" \
+	GO15VENDOREXPERIMENT=1 gox -osarch="linux/386 linux/amd64" \
 		-output="build/zeus-{{.OS}}-{{.Arch}}" \
 		$(PACKAGE)/go/cmd/zeus
 
@@ -155,7 +155,6 @@ clean:
 
 .PHONY: dev_bootstrap
 dev_bootstrap: go/zeusversion/zeusversion.go
-	go get ./...
 	bundle -v || gem install bundler --no-rdoc --no-ri
 	bundle install
-	go get github.com/mitchellh/gox
+	go get github.com/mitchellh/gox github.com/kardianos/govendor

--- a/vendor/github.com/burke/ttyutils/MIT-LICENSE
+++ b/vendor/github.com/burke/ttyutils/MIT-LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2012 Burke Libbey
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/burke/ttyutils/Makefile
+++ b/vendor/github.com/burke/ttyutils/Makefile
@@ -1,0 +1,5 @@
+GOROOT ?= $(shell printf 't:;@echo $$(GOROOT)\n' | gomake -f -)
+
+TARG=github.com/burke/ttyutils
+GOFILES=\
+	ttyutils_$(GOOS).go\

--- a/vendor/github.com/burke/ttyutils/README.md
+++ b/vendor/github.com/burke/ttyutils/README.md
@@ -1,0 +1,23 @@
+# ttyutils
+
+Ttyutils is a simple Go package with a few functions for raw TTY IO.
+
+Currently only supports darwin; will soon support linux. Currently rough.
+
+## Install
+
+    go get github.com/burke/ttyutils
+
+## Example
+
+```go
+package main
+
+import (
+	"github.com/burke/ttyutils"
+)
+
+func main() {
+  // TODO
+}
+```

--- a/vendor/github.com/burke/ttyutils/ttyutils_darwin.go
+++ b/vendor/github.com/burke/ttyutils/ttyutils_darwin.go
@@ -1,0 +1,123 @@
+package ttyutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	ISTRIP       = 0x20
+	INLCR        = 0x40
+	ICRNL        = 0x100
+	IEXTEN       = 0x400
+	ECHOE        = 0x02
+	ECHOK        = 0x04
+	OPOST        = 0x01
+	IMAXBEL      = 0x2000
+	IGNBRK       = 0x01
+	BRKINT       = 0x02
+	IGNCR        = 0x80
+	IXON         = 0x200
+	IXOFF        = 0x400
+	ICANON       = 0x100
+	ISIG         = 0x80
+	termios_NCCS = 20
+)
+
+type tcflag_t uint64 // unsigned long
+type cc_t byte       // unsigned char
+type speed_t uint64  // unsigned long
+
+type Termios struct {
+	Iflag  tcflag_t           /* input flags */
+	Oflag  tcflag_t           /* output flags */
+	Cflag  tcflag_t           /* control flags */
+	Lflag  tcflag_t           /* local flags */
+	Cc     [termios_NCCS]cc_t /* control chars */
+	Ispeed speed_t            /* input speed */
+	Ospeed speed_t            /* output speed */
+}
+
+type Ttysize struct {
+	Lines   uint16
+	Columns uint16
+}
+
+func IsTerminal(fd uintptr) bool {
+	var termios Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}
+
+func Winsize(of *os.File) (Ttysize, error) {
+	var ts Ttysize
+	err := ioctl(of.Fd(), syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ts)))
+	return ts, err
+}
+
+func MirrorWinsize(from, to *os.File) error {
+	var n int
+	err := ioctl(from.Fd(), syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return err
+	}
+	err = ioctl(to.Fd(), syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ioctl(fd uintptr, cmd uintptr, ptr uintptr) error {
+	_, _, e := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		cmd,
+		uintptr(unsafe.Pointer(ptr)),
+	)
+	if e != 0 {
+		return errors.New(fmt.Sprintf("ioctl failed! %s", e))
+	}
+	return nil
+}
+
+func NoEcho(fd uintptr) (*Termios, error) {
+	var s Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	oldState := s
+	s.Lflag &^= syscall.ECHO | ECHOE | ECHOK
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+func MakeTerminalRaw(fd uintptr) (*Termios, error) {
+	var s Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	oldState := s
+	s.Iflag &^= ISTRIP | INLCR | ICRNL | IGNCR | IXON | IXOFF | IMAXBEL | BRKINT
+	s.Iflag |= IGNBRK
+	s.Lflag &^= syscall.ECHO | ICANON | ISIG | IEXTEN | ECHOE | ECHOK
+	s.Oflag &^= OPOST
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+func RestoreTerminalState(fd uintptr, termios *Termios) error {
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(termios)), 0, 0, 0)
+	return err
+}

--- a/vendor/github.com/burke/ttyutils/ttyutils_linux.go
+++ b/vendor/github.com/burke/ttyutils/ttyutils_linux.go
@@ -1,0 +1,92 @@
+package ttyutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+type Termios syscall.Termios
+
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}
+
+type Ttysize struct {
+	Lines   uint16
+	Columns uint16
+}
+
+func Winsize(of *os.File) (Ttysize, error) {
+	var ts Ttysize
+	err := ioctl(of.Fd(), syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ts)))
+	return ts, err
+}
+
+func MirrorWinsize(from, to *os.File) error {
+	var n int
+	err := ioctl(from.Fd(), syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return err
+	}
+	err = ioctl(to.Fd(), syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ioctl(fd uintptr, cmd uintptr, ptr uintptr) error {
+	_, _, e := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		cmd,
+		uintptr(unsafe.Pointer(ptr)),
+	)
+	if e != 0 {
+		return errors.New(fmt.Sprintf("ioctl failed! %s", e))
+	}
+	return nil
+}
+
+func NoEcho(fd uintptr) (*Termios, error) {
+	var s Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	oldState := s
+	s.Lflag &^= syscall.ECHO | syscall.ECHOE | syscall.ECHOK
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+func MakeTerminalRaw(fd uintptr) (*Termios, error) {
+	var s Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	oldState := s
+	s.Iflag &^= syscall.ISTRIP | syscall.INLCR | syscall.ICRNL | syscall.IGNCR | syscall.IXON | syscall.IXOFF | syscall.IMAXBEL | syscall.BRKINT
+	s.Iflag |= syscall.IGNBRK
+	s.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG | syscall.IEXTEN | syscall.ECHOE | syscall.ECHOK
+	s.Oflag &^= syscall.OPOST
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&s)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+
+	return &oldState, nil
+}
+
+func RestoreTerminalState(fd uintptr, termios *Termios) error {
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(termios)), 0, 0, 0)
+	return err
+}

--- a/vendor/github.com/kr/pty/License
+++ b/vendor/github.com/kr/pty/License
@@ -1,0 +1,23 @@
+Copyright (c) 2011 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kr/pty/README.md
+++ b/vendor/github.com/kr/pty/README.md
@@ -1,0 +1,36 @@
+# pty
+
+Pty is a Go package for using unix pseudo-terminals.
+
+## Install
+
+    go get github.com/kr/pty
+
+## Example
+
+```go
+package main
+
+import (
+	"github.com/kr/pty"
+	"io"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	c := exec.Command("grep", "--color=auto", "bar")
+	f, err := pty.Start(c)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		f.Write([]byte("foo\n"))
+		f.Write([]byte("bar\n"))
+		f.Write([]byte("baz\n"))
+		f.Write([]byte{4}) // EOT
+	}()
+	io.Copy(os.Stdout, f)
+}
+```

--- a/vendor/github.com/kr/pty/doc.go
+++ b/vendor/github.com/kr/pty/doc.go
@@ -1,0 +1,16 @@
+// Package pty provides functions for working with Unix terminals.
+package pty
+
+import (
+	"errors"
+	"os"
+)
+
+// ErrUnsupported is returned if a function is not
+// available on the current platform.
+var ErrUnsupported = errors.New("unsupported")
+
+// Opens a pty and its corresponding tty.
+func Open() (pty, tty *os.File, err error) {
+	return open()
+}

--- a/vendor/github.com/kr/pty/ioctl.go
+++ b/vendor/github.com/kr/pty/ioctl.go
@@ -1,0 +1,11 @@
+package pty
+
+import "syscall"
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/vendor/github.com/kr/pty/ioctl_bsd.go
+++ b/vendor/github.com/kr/pty/ioctl_bsd.go
@@ -1,0 +1,39 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package pty
+
+// from <sys/ioccom.h>
+const (
+	_IOC_VOID    uintptr = 0x20000000
+	_IOC_OUT     uintptr = 0x40000000
+	_IOC_IN      uintptr = 0x80000000
+	_IOC_IN_OUT  uintptr = _IOC_OUT | _IOC_IN
+	_IOC_DIRMASK         = _IOC_VOID | _IOC_OUT | _IOC_IN
+
+	_IOC_PARAM_SHIFT = 13
+	_IOC_PARAM_MASK  = (1 << _IOC_PARAM_SHIFT) - 1
+)
+
+func _IOC_PARM_LEN(ioctl uintptr) uintptr {
+	return (ioctl >> 16) & _IOC_PARAM_MASK
+}
+
+func _IOC(inout uintptr, group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return inout | (param_len&_IOC_PARAM_MASK)<<16 | uintptr(group)<<8 | ioctl_num
+}
+
+func _IO(group byte, ioctl_num uintptr) uintptr {
+	return _IOC(_IOC_VOID, group, ioctl_num, 0)
+}
+
+func _IOR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_OUT, group, ioctl_num, param_len)
+}
+
+func _IOW(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN, group, ioctl_num, param_len)
+}
+
+func _IOWR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN_OUT, group, ioctl_num, param_len)
+}

--- a/vendor/github.com/kr/pty/mktypes.bash
+++ b/vendor/github.com/kr/pty/mktypes.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+GOOSARCH="${GOOS}_${GOARCH}"
+case "$GOOSARCH" in
+_* | *_ | _)
+	echo 'undefined $GOOS_$GOARCH:' "$GOOSARCH" 1>&2
+	exit 1
+	;;
+esac
+
+GODEFS="go tool cgo -godefs"
+
+$GODEFS types.go |gofmt > ztypes_$GOARCH.go
+
+case $GOOS in
+freebsd)
+	$GODEFS types_$GOOS.go |gofmt > ztypes_$GOOSARCH.go
+	;;
+esac

--- a/vendor/github.com/kr/pty/pty_darwin.go
+++ b/vendor/github.com/kr/pty/pty_darwin.go
@@ -1,0 +1,60 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = grantpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = unlockpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func ptsname(f *os.File) (string, error) {
+	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
+
+	err := ioctl(f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range n {
+		if c == 0 {
+			return string(n[:i]), nil
+		}
+	}
+	return "", errors.New("TIOCPTYGNAME string not NUL-terminated")
+}
+
+func grantpt(f *os.File) error {
+	return ioctl(f.Fd(), syscall.TIOCPTYGRANT, 0)
+}
+
+func unlockpt(f *os.File) error {
+	return ioctl(f.Fd(), syscall.TIOCPTYUNLK, 0)
+}

--- a/vendor/github.com/kr/pty/pty_freebsd.go
+++ b/vendor/github.com/kr/pty/pty_freebsd.go
@@ -1,0 +1,73 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func posix_openpt(oflag int) (fd int, err error) {
+	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
+	fd = int(r0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func open() (pty, tty *os.File, err error) {
+	fd, err := posix_openpt(syscall.O_RDWR | syscall.O_CLOEXEC)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := os.NewFile(uintptr(fd), "/dev/pts")
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile("/dev/"+sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func isptmaster(fd uintptr) (bool, error) {
+	err := ioctl(fd, syscall.TIOCPTMASTER, 0)
+	return err == nil, err
+}
+
+var (
+	emptyFiodgnameArg fiodgnameArg
+	ioctl_FIODGNAME   = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+)
+
+func ptsname(f *os.File) (string, error) {
+	master, err := isptmaster(f.Fd())
+	if err != nil {
+		return "", err
+	}
+	if !master {
+		return "", syscall.EINVAL
+	}
+
+	const n = _C_SPECNAMELEN + 1
+	var (
+		buf = make([]byte, n)
+		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
+	)
+	err = ioctl(f.Fd(), ioctl_FIODGNAME, uintptr(unsafe.Pointer(&arg)))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range buf {
+		if c == 0 {
+			return string(buf[:i]), nil
+		}
+	}
+	return "", errors.New("FIODGNAME string not NUL-terminated")
+}

--- a/vendor/github.com/kr/pty/pty_linux.go
+++ b/vendor/github.com/kr/pty/pty_linux.go
@@ -1,0 +1,46 @@
+package pty
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = unlockpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func ptsname(f *os.File) (string, error) {
+	var n _C_uint
+	err := ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return "", err
+	}
+	return "/dev/pts/" + strconv.Itoa(int(n)), nil
+}
+
+func unlockpt(f *os.File) error {
+	var u _C_int
+	// use TIOCSPTLCK with a zero valued arg to clear the slave pty lock
+	return ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}

--- a/vendor/github.com/kr/pty/pty_unsupported.go
+++ b/vendor/github.com/kr/pty/pty_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux,!darwin,!freebsd
+
+package pty
+
+import (
+	"os"
+)
+
+func open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrUnsupported
+}

--- a/vendor/github.com/kr/pty/run.go
+++ b/vendor/github.com/kr/pty/run.go
@@ -1,0 +1,32 @@
+package pty
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Start assigns a pseudo-terminal tty os.File to c.Stdin, c.Stdout,
+// and c.Stderr, calls c.Start, and returns the File of the tty's
+// corresponding pty.
+func Start(c *exec.Cmd) (pty *os.File, err error) {
+	pty, tty, err := Open()
+	if err != nil {
+		return nil, err
+	}
+	defer tty.Close()
+	c.Stdout = tty
+	c.Stdin = tty
+	c.Stderr = tty
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setctty = true
+	c.SysProcAttr.Setsid = true
+	err = c.Start()
+	if err != nil {
+		pty.Close()
+		return nil, err
+	}
+	return pty, err
+}

--- a/vendor/github.com/kr/pty/types.go
+++ b/vendor/github.com/kr/pty/types.go
@@ -1,0 +1,10 @@
+// +build ignore
+
+package pty
+
+import "C"
+
+type (
+	_C_int  C.int
+	_C_uint C.uint
+)

--- a/vendor/github.com/kr/pty/types_freebsd.go
+++ b/vendor/github.com/kr/pty/types_freebsd.go
@@ -1,0 +1,15 @@
+// +build ignore
+
+package pty
+
+/*
+#include <sys/param.h>
+#include <sys/filio.h>
+*/
+import "C"
+
+const (
+	_C_SPECNAMELEN = C.SPECNAMELEN /* max length of devicename */
+)
+
+type fiodgnameArg C.struct_fiodgname_arg

--- a/vendor/github.com/kr/pty/util.go
+++ b/vendor/github.com/kr/pty/util.go
@@ -1,0 +1,35 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Getsize returns the number of rows (lines) and cols (positions
+// in each line) in terminal t.
+func Getsize(t *os.File) (rows, cols int, err error) {
+	var ws winsize
+	err = windowrect(&ws, t.Fd())
+	return int(ws.ws_row), int(ws.ws_col), err
+}
+
+type winsize struct {
+	ws_row    uint16
+	ws_col    uint16
+	ws_xpixel uint16
+	ws_ypixel uint16
+}
+
+func windowrect(ws *winsize, fd uintptr) error {
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		syscall.TIOCGWINSZ,
+		uintptr(unsafe.Pointer(ws)),
+	)
+	if errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return nil
+}

--- a/vendor/github.com/kr/pty/ztypes_386.go
+++ b/vendor/github.com/kr/pty/ztypes_386.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_amd64.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_arm.go
+++ b/vendor/github.com/kr/pty/ztypes_arm.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_arm64.go
+++ b/vendor/github.com/kr/pty/ztypes_arm64.go
@@ -1,0 +1,11 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+// +build arm64
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_freebsd_386.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_386.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len int32
+	Buf *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_freebsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_amd64.go
@@ -1,0 +1,14 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len       int32
+	Pad_cgo_0 [4]byte
+	Buf       *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_freebsd_arm.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_arm.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len int32
+	Buf *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_ppc64.go
+++ b/vendor/github.com/kr/pty/ztypes_ppc64.go
@@ -1,0 +1,11 @@
+// +build ppc64
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_ppc64le.go
+++ b/vendor/github.com/kr/pty/ztypes_ppc64le.go
@@ -1,0 +1,11 @@
+// +build ppc64le
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_s390x.go
+++ b/vendor/github.com/kr/pty/ztypes_s390x.go
@@ -1,0 +1,11 @@
+// +build s390x
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,19 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "dtEdpOSac112PT/mVhmLCLvx8qw=",
+			"path": "github.com/burke/ttyutils",
+			"revision": "70f0d73eb47f7033f514f7f8f5138152fe1088fc",
+			"revisionTime": "2012-12-05T23:31:21Z"
+		},
+		{
+			"checksumSHA1": "P29nLcVx4WzwhEDgDTCN76rS5WI=",
+			"path": "github.com/kr/pty",
+			"revision": "f7ee69f31298ecbe5d2b349c711e2547a617d398",
+			"revisionTime": "2015-10-07T23:04:24Z"
+		}
+	],
+	"rootPath": "github.com/burke/zeus"
+}


### PR DESCRIPTION
Neither of the two existing Go dependencies discuss versioning or API compatibility. In https://github.com/burke/zeus/pull/550 I'm proposing to introduce a dependency on an external library that [explicitly anticipates API changes](https://github.com/fsnotify/fsevents/commit/83a642eb3ec3336b04a0cfaff0a897dc26652790#diff-04c6e90faac2675aa89e2176d2eec7d8).

Vendoring dependencies into zeus breaks our reliance on the stability of these libraries and ensures reproducible builds. Vendor support in the Go toolchain is now standard in Go 1.6 and [recommended for vendoring dependencies by the Go team](https://github.com/golang/go/wiki/PackageManagementTools#go15vendorexperiment).
