### PR TITLE
Force test environmnet in custom plans

### DIFF
--- a/examples/custom_plan/cucumber_plan.rb
+++ b/examples/custom_plan/cucumber_plan.rb
@@ -9,6 +9,7 @@ require 'zeus/rails'
 
 class CucumberPlan < Zeus::Rails         
   def cucumber_environment
+    ::Rails.env = ENV['RAILS_ENV'] = 'test'
     require 'cucumber/rspec/disable_option_parser'
     require 'cucumber/cli/main'
     @cucumber_runtime = Cucumber::Runtime.new


### PR DESCRIPTION
Cucumber seems to run in the development environment with the example plan shown. This PR recommends forcing it to use the test environment for cucumber tests. 

The main reason for this is because many people have `config.cache_classes` set to `false` for development, which prevents cucumber tests from running properly if you also use transactions as a database cleanup strategy (also a very common setting). 