### PR TITLE
Fix adding files to filemonitor under OS X

### DIFF
--- a/go/filemonitor/filemonitor_darwin.go
+++ b/go/filemonitor/filemonitor_darwin.go
@@ -102,6 +102,7 @@ func (f *fsEventsMonitor) handleAdd() {
 		}
 
 		for _, file := range allFiles {
+			watched[file] = true
 			f.stream.Paths = append(f.stream.Paths, file)
 		}
 


### PR DESCRIPTION
We were correctly checking whether a file was already watched before adding it to our watch list but not correctly marking it as watched. This resulted in some speed and reliability issues on OS X since:
https://github.com/burke/zeus/pull/550