### PR TITLE
Add support for delayed feature reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
 before_install:
   - rvm use $USE_RUBY --install --fuzzy
 install:
-  - make dev_bootstrap
-  - make rubygem/lib/zeus/version.rb
+  - make dev_bootstrap linux
 script:
-  - make test-go
-  - make build-linux
-  - make rubygem/lib/zeus/version.rb && cd rubygem && bundle install --without development && bin/rspec spec
+  - make test

--- a/rubygem/lib/zeus/load_tracking.rb
+++ b/rubygem/lib/zeus/load_tracking.rb
@@ -3,6 +3,7 @@ module Zeus
     class << self
       def features_loaded_by(&block)
         old_features = all_features
+        @tracking_features = true
 
         # Catch exceptions so we can determine the features
         # that were being loaded at the time of the exception.
@@ -24,6 +25,7 @@ module Zeus
                              .take_while { |f| f != __FILE__ }
         end
 
+        @tracking_features = false
         new_features = all_features + err_features - old_features
         new_features.uniq!
 
@@ -50,8 +52,12 @@ module Zeus
       private
 
       def add_extra_feature(path)
-        $untracked_features ||= []
-        $untracked_features << path
+        if @tracking_features
+          $untracked_features ||= []
+          $untracked_features << path
+        else
+          Zeus.notify_features([path])
+        end
       end
 
       def find_in_load_path(file_path)

--- a/rubygem/spec/assets/boot.rb
+++ b/rubygem/spec/assets/boot.rb
@@ -1,0 +1,2 @@
+# This is a single ruby file that doesn't do anything for testing Zeus
+# load tracking during boot.

--- a/rubygem/spec/assets/boot_delayed.rb
+++ b/rubygem/spec/assets/boot_delayed.rb
@@ -1,0 +1,2 @@
+# This is a single ruby file that doesn't do anything for testing Zeus
+# load tracking after boot.

--- a/rubygem/spec/zeus_spec.rb
+++ b/rubygem/spec/zeus_spec.rb
@@ -1,0 +1,85 @@
+require 'zeus'
+
+describe Zeus do
+  class MyTestPlan < Zeus::Plan
+    def self.mutex
+      @mutex ||= Mutex.new
+    end
+
+    def self.boot
+      require_relative 'assets/boot'
+      Thread.new do
+        mutex.synchronize do
+          Zeus::LoadTracking.add_feature(File.join(__dir__, 'assets', 'boot_delayed.rb'))
+        end
+      end
+    end
+  end
+
+  Zeus.plan = MyTestPlan
+
+  before do
+    MyTestPlan.mutex.lock
+  end
+
+  after do
+    MyTestPlan.mutex.unlock if MyTestPlan.mutex.locked?
+  end
+
+  context 'booting' do
+    before do
+      # Don't reopen STDOUT
+      Zeus.dummy_tty = true
+    end
+
+    it 'boots and tracks features' do
+      master_r, master_w = UNIXSocket.pair(Socket::SOCK_STREAM)
+      ENV['ZEUS_MASTER_FD'] = master_w.to_i.to_s
+
+      thr = Thread.new do
+        begin
+          Zeus.go
+        rescue Interrupt
+          return
+        rescue => e
+          STDERR.puts "Zeus terminated with exception: #{e.message}"
+          STDERR.puts e.backtrace.map {|line| " #{line}"}
+        end
+      end
+
+      begin
+        # Receive the control IO and start message
+        ctrl_io = master_r.recv_io(UNIXSocket)
+        begin
+          # We use recv instead of readline on the UNIXSocket to avoid
+          # converting it to a buffered reader. That seems to interact
+          # badly with passing file descriptors around on Linux.
+          proc_msg = "P:#{Process.pid}:boot\0"
+          expect(ctrl_io.recv(proc_msg.length)).to eq(proc_msg)
+
+          feature_io = ctrl_io.recv_io
+
+          ready_msg = "R:OK\0"
+          expect(ctrl_io.recv(ready_msg.length)).to eq(ready_msg)
+          begin
+            # We should receive the synchronously required feature immediately
+            expect(feature_io.readline).to eq(File.join(__dir__, 'assets', 'boot.rb') + "\n")
+
+            # We should receive the delayed feature after unlocking its mutex
+            MyTestPlan.mutex.unlock
+            expect(feature_io.readline).to eq(File.join(__dir__, 'assets', 'boot_delayed.rb') + "\n")
+          ensure
+            feature_io.close
+          end
+        ensure
+          ctrl_io.close
+        end
+      ensure
+        thr.raise(Interrupt.new)
+      end
+    end
+
+    it 'tracks features after booting has completed' do
+    end
+  end
+end


### PR DESCRIPTION
Zeus currently only reports features once when the action it executes completes. Many of our actions spawn long running server processes in a new thread. These can subsequently require new files (especially if you're using an autoloader). 

This PR adds support for calling `Zeus.notify_features` *after* an action has run to report additional features to Zeus.