### PR TITLE
Simplify and remove some races from SlaveNode state machine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - make dev_bootstrap
   - make rubygem/lib/zeus/version.rb
 script:
-  - make test-go
+  - RAILS_ENV="" make test-go
   - make build-linux
   - make rubygem/lib/zeus/version.rb && cd rubygem && bundle install --without development && bin/rspec spec

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ compileLinuxBinaries:
 
 go/zeusversion/zeusversion.go: VERSION
 	mkdir -p $(@D)
-	@echo 'package zeusversion\n\nconst VERSION string = "$(VERSION)"' > $@
+	@echo 'package zeusversion\n\nconst VERSION string = "$(VERSION)$(GO_VERSION_SUFFIX)"' > $@
 rubygem/lib/zeus/version.rb: VERSION
 	mkdir -p $(@D)
 	@echo 'module Zeus\n  VERSION = "$(VERSION)"\nend' > $@

--- a/go/clienthandler/clienthandler.go
+++ b/go/clienthandler/clienthandler.go
@@ -204,7 +204,7 @@ func receivePidFromCommand(commandUsock *unixsocket.Usock, err error) (int, erro
 	if err != nil {
 		return -1, err
 	}
-	intPid, _, _ := messages.ParsePidMessage(msg)
+	intPid, _, _, _ := messages.ParsePidMessage(msg)
 
 	return intPid, err
 }

--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -86,7 +86,7 @@ func main() {
 			if args[0] == name {
 				// Don't confuse the master by sending *full* args to
 				// it; just those that are not zeus-specific.
-				os.Exit(zeusclient.Run(args))
+				os.Exit(zeusclient.Run(args, os.Stdin, os.Stdout))
 			}
 		}
 

--- a/go/messages/messages.go
+++ b/go/messages/messages.go
@@ -6,19 +6,24 @@ import (
 	"strings"
 )
 
-func ParsePidMessage(msg string) (int, string, error) {
-	parts := strings.SplitN(msg, ":", 3)
+func ParsePidMessage(msg string) (int, int, string, error) {
+	parts := strings.SplitN(msg, ":", 4)
 	if parts[0] != "P" {
-		return -1, "", errors.New("Wrong message type! Expected PidMessage, got: " + msg)
+		return -1, -1, "", errors.New("Wrong message type! Expected PidMessage, got: " + msg)
 	}
 
-	identifier := parts[2]
+	identifier := parts[3]
 	pid, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return -1, "", err
+		return -1, -1, "", err
 	}
 
-	return pid, identifier, nil
+	parent, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return -1, -1, "", err
+	}
+
+	return pid, parent, identifier, nil
 }
 
 func CreateCommandAndArgumentsMessage(args []string, pid int) string {

--- a/go/processtree/processtree.go
+++ b/go/processtree/processtree.go
@@ -76,7 +76,7 @@ func (tree *ProcessTree) RestartNodesWithFeatures(files []string) {
 // Serialized: restartMutex is always held when this is called.
 func (node *SlaveNode) restartNodesWithFeatures(tree *ProcessTree, files []string) {
 	for _, file := range files {
-		if node.Features[file] {
+		if node.HasFeature(file) {
 			node.RequestRestart()
 			return
 		}

--- a/go/processtree/slavemonitor.go
+++ b/go/processtree/slavemonitor.go
@@ -88,7 +88,7 @@ func (mon *SlaveMonitor) slaveDidBeginRegistration(fd int) {
 	if err != nil {
 		slog.Error(err)
 	}
-	pid, identifier, err := messages.ParsePidMessage(msg)
+	pid, parentPid, identifier, err := messages.ParsePidMessage(msg)
 
 	// And the last step before executing its action, the slave sends us a pipe it will later use to
 	// send us all the features it's loaded.
@@ -102,5 +102,5 @@ func (mon *SlaveMonitor) slaveDidBeginRegistration(fd int) {
 		Error("slavemonitor.go:slaveDidBeginRegistration:Unknown identifier:" + identifier)
 	}
 
-	slaveNode.SlaveWasInitialized(pid, slaveUsock, featurePipeFd)
+	slaveNode.SlaveWasInitialized(pid, parentPid, slaveUsock, featurePipeFd)
 }

--- a/go/processtree/slavenode.go
+++ b/go/processtree/slavenode.go
@@ -21,22 +21,18 @@ import (
 
 type SlaveNode struct {
 	ProcessTreeNode
-	socket                *unixsocket.Usock
-	featurePipe           *os.File
-	Pid                   int
-	Error                 string
-	Slaves                []*SlaveNode
-	Commands              []*CommandNode
-	fileMonitor           filemonitor.FileMonitor
-	featureHandlerRunning bool
+	socket      *unixsocket.Usock
+	pid         int
+	Error       string
+	Slaves      []*SlaveNode
+	Commands    []*CommandNode
+	fileMonitor filemonitor.FileMonitor
 
 	hasSuccessfullyBooted bool
 
-	needsRestart        chan bool            // size 1
-	commandBootRequests chan *CommandRequest // size 256
-	slaveBootRequests   chan *SlaveNode      // size 256
-	parentReadiness     chan bool            // size 256 (TODO: rename me)
-	childBootRequests   chan *SlaveNode      // size 1
+	needsRestart        chan bool
+	slaveBootRequests   chan *SlaveNode
+	commandBootRequests chan *CommandRequest
 
 	L        sync.Mutex
 	features map[string]bool
@@ -57,7 +53,6 @@ type CommandRequest struct {
 }
 
 const (
-	SWaiting  = "W"
 	SUnbooted = "U"
 	SBooting  = "B"
 	SReady    = "R"
@@ -67,12 +62,10 @@ const (
 func (tree *ProcessTree) NewSlaveNode(identifier string, parent *SlaveNode, monitor filemonitor.FileMonitor) *SlaveNode {
 	s := SlaveNode{}
 	s.needsRestart = make(chan bool, 1)
-	s.commandBootRequests = make(chan *CommandRequest, 256)
 	s.slaveBootRequests = make(chan *SlaveNode, 256)
-	s.parentReadiness = make(chan bool, 1)
-	s.childBootRequests = make(chan *SlaveNode, 256)
+	s.commandBootRequests = make(chan *CommandRequest, 256)
 	s.features = make(map[string]bool)
-	s.event = make(chan bool, 1)
+	s.event = make(chan bool)
 	s.Name = identifier
 	s.Parent = parent
 	s.fileMonitor = monitor
@@ -80,79 +73,74 @@ func (tree *ProcessTree) NewSlaveNode(identifier string, parent *SlaveNode, moni
 	return &s
 }
 
-// If the slave is executing, or has executed its action, trigger a restart.
-// There's no need to trigger a restart if the slave has not yet begun to
-// execute its action, and there's no need to queue multiple restarts.
 func (s *SlaveNode) RequestRestart() {
-	s.requestRestart(false)
-}
+	s.L.Lock()
+	defer s.L.Unlock()
 
-func (s *SlaveNode) requestRestart(asChild bool) {
-	state := s.State()
-	if state == SBooting || state == SReady || state == SCrashed || state == SWaiting {
-		// Enqueue the restart if there isn't already one in the channel
-		select {
-		case s.needsRestart <- asChild:
-		default:
-		}
-	}
-	for _, slave := range s.Slaves {
-		state := slave.State()
-		if state == SBooting || state == SReady || state == SCrashed {
-			slave.requestRestart(true)
-		}
+	// If this slave is currently waiting on process to boot,
+	// unhang it. If it isn't, the error will get wiped anyway.
+	s.Error = "Received restart request while booting"
+	s.ReportBootEvent()
+
+	// Enqueue the restart if there isn't already one in the channel
+	select {
+	case s.needsRestart <- true:
+	default:
 	}
 }
 
 func (s *SlaveNode) RequestSlaveBoot(slave *SlaveNode) {
-	s.L.Lock()
 	s.slaveBootRequests <- slave
-	s.L.Unlock()
 }
 
 func (s *SlaveNode) RequestCommandBoot(request *CommandRequest) {
-	s.L.Lock()
 	s.commandBootRequests <- request
-	s.L.Unlock()
+}
+
+func (s *SlaveNode) ReportBootEvent() bool {
+	select {
+	case s.event <- true:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *SlaveNode) SlaveWasInitialized(pid int, usock *unixsocket.Usock, featurePipeFd int) {
 	file := os.NewFile(uintptr(featurePipeFd), "featurepipe")
 
 	s.L.Lock()
-	s.wipe()
-	s.featurePipe = file
-	s.Pid = pid
-	s.socket = usock
-	if s.state == SUnbooted {
-		s.event <- true
-	} else {
+	if !s.ReportBootEvent() {
 		if pid > 0 {
 			syscall.Kill(pid, syscall.SIGKILL)
 		}
-		slog.ErrorString("Unexpected process for slave `" + s.Name + "` was killed")
+		slog.ErrorString(fmt.Sprintf("Unexpected process %d for slave %q was killed", pid, s.Name))
+	} else {
+		s.wipe()
+		s.pid = pid
+		s.socket = usock
+		go s.handleMessages(file)
+		s.trace("initialized slave %s with pid %d", s.Name, pid)
 	}
 	s.L.Unlock()
 }
 
 func (s *SlaveNode) Run(monitor *SlaveMonitor) {
-	nextState := SWaiting
+	nextState := SUnbooted
 	for {
 		s.L.Lock()
 		s.state = nextState
 		s.L.Unlock()
 		monitor.tree.StateChanged <- true
 		switch nextState {
-		case SWaiting:
-			nextState = s.doWaitingState()
 		case SUnbooted:
 			nextState = s.doUnbootedState(monitor)
 		case SBooting:
 			nextState = s.doBootingState()
-		case SCrashed:
-			nextState = s.doCrashedOrReadyState()
 		case SReady:
-			nextState = s.doCrashedOrReadyState()
+			nextState = s.doReadyState()
+		case SCrashed:
+			nextState = s.doCrashedState()
 		default:
 			slog.FatalErrorString("Unrecognized state: " + nextState)
 		}
@@ -175,27 +163,10 @@ func (s *SlaveNode) HasFeature(file string) bool {
 // These "doXState" functions are called when a SlaveNode enters a state. They are expected
 // to continue to execute until
 
-// The "SWaiting" state represents the state where a Slave is currently
-// not running, and neither is its parent. Before we can start booting
-// this slave, we must first wait for its parent to finish booting, so
-// that we can fork off of it.
-func (s *SlaveNode) doWaitingState() string { // -> SUnbooted
-	if s.Parent == nil {
-		// this is the root state. We get to skip this step. Hooray!
-		return SUnbooted
-	}
-	s.Parent.childBootRequests <- s
-	select {
-	case <-s.parentReadiness:
-		s.trace("my parent is ready now")
-	}
-	return SUnbooted
-}
-
-// "SUnbooted" represents the state where the parent process is ready, but
-// we do not yet have the PID of a process to use for *this* node. In this
-// state, we tell the parent process to spawn a process for us, and wait
-// to hear back from the SlaveMonitor.
+// "SUnbooted" represents the state where we do not yet have the PID
+// of a process to use for *this* node. In this state, we wait for the
+// parent process to spawn a process for us and hear back from the
+// SlaveMonitor.
 func (s *SlaveNode) doUnbootedState(monitor *SlaveMonitor) string { // -> {SBooting, SCrashed}
 	s.trace("in unbooted state")
 	if s.Parent == nil {
@@ -210,7 +181,9 @@ func (s *SlaveNode) doUnbootedState(monitor *SlaveMonitor) string { // -> {SBoot
 	} else {
 		s.Parent.RequestSlaveBoot(s)
 	}
-	<-s.event // sent by StateWasInitialized
+
+	<-s.event // sent by SlaveWasInitialized
+
 	s.L.Lock()
 	defer s.L.Unlock()
 	if s.Error != "" {
@@ -221,7 +194,7 @@ func (s *SlaveNode) doUnbootedState(monitor *SlaveMonitor) string { // -> {SBoot
 
 // In "SBooting", we have a pid and socket to the process we will use,
 // but it has not yet finished initializing (generally, running the code
-// specific to this slave. When we receive a message about the success or
+// specific to this slave). When we receive a message about the success or
 // failure of this operation, we transition to either crashed or ready.
 func (s *SlaveNode) doBootingState() string { // -> {SCrashed, SReady}
 	// The slave will execute its action and respond with a status...
@@ -242,41 +215,22 @@ func (s *SlaveNode) doBootingState() string { // -> {SCrashed, SReady}
 		return SReady
 	}
 
-	// Drain the process's feature messages, if we have any, so
-	// that reloads happen when any load-time problems get fixed:
-	s.L.Unlock()
-	s.handleMessages(s.featurePipe)
-	s.L.Lock()
-
 	// Clean up:
-	if s.Pid > 0 {
-		syscall.Kill(s.Pid, syscall.SIGKILL)
+	if s.pid > 0 {
+		syscall.Kill(s.pid, syscall.SIGKILL)
 	}
 	s.wipe()
 	s.Error = msg
 	return SCrashed
 }
 
-// In the "SCrashed" and "SReady" states, we have either a functioning
-// process we can spawn new processes off of, or an error message to
-// propagate to the user. The high-level operation of these two states
-// is identical: First, we work off the queue of command and slave
-// boot requests that have built up while this process was
-// booting. Then, we begin a 4-way select over those channels, the
-// "restart" channel (which kills the process and transitions us to
-// "SWaiting") and a channel for restarted children to request booting.
-// In this way, we always serve queued fork requests before killing the process.
-func (s *SlaveNode) doCrashedOrReadyState() string { // -> SWaiting
-	s.L.Lock()
-	if s.state == SReady && !s.featureHandlerRunning {
-		s.hasSuccessfullyBooted = true
-		s.featureHandlerRunning = true
-		s.trace("entered state SReady")
-		go s.handleMessages(s.featurePipe)
-	}
-	s.L.Unlock()
-
-	s.bootQueuedCommandsAndSlaves()
+// In the "SReady" state, we have a functioning process we can spawn
+// new processes of of. We respond to requests to boot slaves and
+// run commands until we receive a request to restart. This kills
+// the process and transitions to SUnbooted.
+func (s *SlaveNode) doReadyState() string { // -> SUnbooted
+	s.hasSuccessfullyBooted = true
+	s.trace("entered state SReady")
 
 	for {
 		select {
@@ -285,32 +239,51 @@ func (s *SlaveNode) doCrashedOrReadyState() string { // -> SWaiting
 			s.ForceKill()
 			s.wipe()
 			s.L.Unlock()
-			return SWaiting
-		case child := <-s.childBootRequests:
-			child.parentReadiness <- true
+
+			for _, slave := range s.Slaves {
+				slave.RequestRestart()
+			}
+			return SUnbooted
 		case slave := <-s.slaveBootRequests:
-			s.L.Lock()
-			s.trace("now sending slave boot request to %s", slave.Name)
 			s.bootSlave(slave)
+		case request := <-s.commandBootRequests:
+			s.bootCommand(request)
+		}
+	}
+}
+
+// In the "SCrashed" state, we have an error message from starting
+// a process to propogate to the user and all slave nodes. We will
+// continue propogating the error until we receive a request to restart.
+func (s *SlaveNode) doCrashedState() string { // -> SUnbooted
+	for {
+		select {
+		case <-s.needsRestart:
+			s.L.Lock()
+			s.ForceKill()
+			s.wipe()
 			s.L.Unlock()
+			return SUnbooted
+		case slave := <-s.slaveBootRequests:
+			slave.L.Lock()
+			slave.Error = s.Error
+			slave.ReportBootEvent()
+			slave.L.Unlock()
 		case request := <-s.commandBootRequests:
 			s.L.Lock()
-			s.trace("now sending command boot request %v", request)
-			s.bootCommand(request)
+			s.trace("reporting crash to command %v", request)
+			request.Retchan <- &CommandReply{SCrashed, nil}
 			s.L.Unlock()
 		}
 	}
 }
 
-// This should only be called while holding a lock on s.L.
 func (s *SlaveNode) bootSlave(slave *SlaveNode) {
-	if s.Error != "" {
-		slave.L.Lock()
-		slave.Error = s.Error
-		slave.event <- true
-		slave.L.Unlock()
-		return
-	}
+	s.L.Lock()
+	defer s.L.Unlock()
+
+	s.trace("now sending slave boot request for %s", slave.Name)
+
 	msg := messages.CreateSpawnSlaveMessage(slave.Name)
 	_, err := s.socket.WriteMessage(msg)
 	if err != nil {
@@ -318,15 +291,15 @@ func (s *SlaveNode) bootSlave(slave *SlaveNode) {
 	}
 }
 
-// This should only be called while holding a lock on s.L.
 // This unfortunately holds the mutex for a little while, and if the
 // command dies super early, the entire slave pretty well deadlocks.
 // TODO: review this.
 func (s *SlaveNode) bootCommand(request *CommandRequest) {
-	if s.state == SCrashed {
-		request.Retchan <- &CommandReply{SCrashed, nil}
-		return
-	}
+	s.L.Lock()
+	defer s.L.Unlock()
+
+	s.trace("now sending command boot request %v", request)
+
 	identifier := request.Name
 	msg := messages.CreateSpawnCommandMessage(identifier)
 	_, err := s.socket.WriteMessage(msg)
@@ -345,29 +318,15 @@ func (s *SlaveNode) bootCommand(request *CommandRequest) {
 	request.Retchan <- &CommandReply{s.state, commandFile}
 }
 
-func (s *SlaveNode) bootQueuedCommandsAndSlaves() {
-	s.L.Lock()
-	for i := 0; i < len(s.commandBootRequests); i += 1 {
-		request := <-s.commandBootRequests
-		s.bootCommand(request)
-	}
-	for i := 0; i < len(s.slaveBootRequests); i += 1 {
-		slave := <-s.slaveBootRequests
-		s.bootSlave(slave)
-	}
-	s.L.Unlock()
-}
-
 func (s *SlaveNode) ForceKill() {
 	// note that we don't try to lock the mutex.
-	if s.Pid > 0 {
-		syscall.Kill(s.Pid, syscall.SIGKILL)
+	if s.pid > 0 {
+		syscall.Kill(s.pid, syscall.SIGKILL)
 	}
 }
 
 func (s *SlaveNode) wipe() {
-	s.Pid = 0
-	s.featurePipe = nil
+	s.pid = 0
 	s.socket = nil
 	s.Error = ""
 }
@@ -396,11 +355,10 @@ func (s *SlaveNode) babysitRootProcess(cmd *exec.Cmd) {
 	} else {
 		s.L.Lock()
 		defer s.L.Unlock()
-		if s.state == SUnbooted {
-			s.trace("root process exited with error. Sending it to crashed state. Message was: %s; output: %s", msg, output)
-			s.Error = fmt.Sprintf("Zeus root process (%s) died with message %s:\n%s", s.Name, msg, output)
-			s.event <- true
-		} else {
+
+		s.trace("root process exited with error. Sending it to crashed state. Message was: %s; output: %s", msg, output)
+		s.Error = fmt.Sprintf("Zeus root process (%s) died with message %s:\n%s", s.Name, msg, output)
+		if !s.ReportBootEvent() {
 			s.trace("Unexpected state for root process to be in at this time: %s", s.state)
 		}
 	}
@@ -432,8 +390,8 @@ func (s *SlaveNode) trace(format string, args ...interface{}) {
 	_, file, line, _ := runtime.Caller(1)
 
 	var prefix string
-	if s.Pid != 0 {
-		prefix = fmt.Sprintf("[%s:%d] %s/(%d)", file, line, s.Name, s.Pid)
+	if s.pid != 0 {
+		prefix = fmt.Sprintf("[%s:%d] %s/(%d)", file, line, s.Name, s.pid)
 	} else {
 		prefix = fmt.Sprintf("[%s:%d] %s/(no PID)", file, line, s.Name)
 	}

--- a/go/statuschart/statuschart.go
+++ b/go/statuschart/statuschart.go
@@ -108,8 +108,6 @@ func printStateInfo(indentation, identifier, state string, verbose, printNewline
 	case processtree.SReady:
 		// no status suffix, as that's the optimal state
 		log.ColorizedSansNl(indentation + "{green}" + identifier + suffix + "\033[K" + newline)
-	case processtree.SWaiting:
-		fallthrough
 	default:
 		log.ColorizedSansNl(indentation + "{yellow}" + identifier + suffix + "\033[K" + newline)
 	}


### PR DESCRIPTION
We've experienced frequent problems with Zeus nodes getting hung in an Unbooted state. I believe I traced it to a race condition that occurs when a parent reboots while a child is locked booting a command. Before tracking that down, I noticed that there was a decent bit of simplification that could be applied to the state machine that should result in better behavior overall and get rid of this particular bug. See individual commit messages for more details.

Given the subtlety of the concurrent operations here, I intend to roll this out to a handful of developers this week and get them to smoke test it before merging anything. 