### PR TITLE
Apply a small debounce to status chart updates

### DIFF
--- a/go/statuschart/stdout.go
+++ b/go/statuschart/stdout.go
@@ -14,7 +14,7 @@ func stdoutStart(tree *processtree.ProcessTree, done, quit chan bool) {
 				done <- true
 				return
 				// TODO: Maybe handle SCW Write requests?
-			case <-tree.StateChanged:
+			case <-theChart.update:
 				theChart.logChanges()
 			}
 		}

--- a/go/statuschart/tty.go
+++ b/go/statuschart/tty.go
@@ -43,8 +43,6 @@ func ttyStart(tree *processtree.ProcessTree, done, quit chan bool) {
 				theChart.extraOutput += output
 				theChart.L.Unlock()
 				theChart.draw()
-			case <-tree.StateChanged:
-				theChart.draw()
 			case <-theChart.update:
 				theChart.draw()
 			}


### PR DESCRIPTION
When a single parent node's status changes, it causes a cascade of updates to child nodes. All of those updates report separate `StateChange`s, frequently causing multiple identical lines to be printed. Adding a very small debounce to the update monitoring avoids this noise while hiding only the most ephemeral state transitions.

r? @ptarjan