### PR TITLE
Revert #530 (requires using Zeus with bundler)

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -1,6 +1,11 @@
 # encoding: utf-8
 require 'socket'
 
+# load exact json version from Gemfile.lock to avoid conflicts
+gemfile = "#{ENV["BUNDLE_GEMFILE"] || "Gemfile"}.lock"
+if File.exist?(gemfile) && version = File.read(gemfile)[/^    json \((.*)\)/, 1]
+  gem 'json', version
+end
 require 'json'
 require 'pty'
 require 'set'

--- a/rubygem/spec/rails_spec.rb
+++ b/rubygem/spec/rails_spec.rb
@@ -65,6 +65,23 @@ module Zeus
       end
     end
 
+    describe "#gem_is_bundled?" do
+      context "for a bundled gem" do
+        it "returns the bundled gem's version" do
+          allow(File).to receive(:read).and_return("
+  GEM
+    remote: https://rubygems.org/
+    specs:
+      exception_notification-rake (0.0.6)
+        exception_notification (~> 3.0.1)
+        rake (>= 0.9.0)
+      rake (10.0.4)
+  ")
+          expect(gem_is_bundled?('rake')).to eq '10.0.4'
+        end
+      end
+    end
+
     describe "#test" do
       def expect_minitest_autorun
         # Zeus::Rails#test_helper will require minitest/unit by default.


### PR DESCRIPTION
This reverts #530.

The README currently advises [running Zeus outside of bundler](https://github.com/burke/zeus/blob/810c8f49798d4f64b16894abd94beedbddb0b37f/README.md#installation). I agree that running Zeus without bundler is probably a bad tradeoff in terms of stability but I don't think we can change this without
[breaking everyone's Zeus integrations](https://github.com/burke/zeus/issues/570). I believe we should revert until we're prepared to re-introduce this with changes to the README, better error messaging to help people transition and possibly a major version bump.