### PR TITLE
Run Travis build on both OS X and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
   - 1.5
+os:
+  - linux
+  - osx
 env:
   - USE_RUBY=2.0.0-p647
   - USE_RUBY=2.1.7


### PR DESCRIPTION
Our filemonitoring code varies by OS but was only being run on Linux in Travis.