### PR TITLE
Report node as crashed if the process exits

### DIFF
--- a/go/processtree/slavenode.go
+++ b/go/processtree/slavenode.go
@@ -230,10 +230,10 @@ func (s *SlaveNode) doBootingState() string { // -> {SCrashed, SReady}
 }
 
 // In the "SReady" state, we have a functioning process we can spawn
-// new processes of of. We respond to requests to boot slaves and
+// new processes off of. We respond to requests to boot slaves and
 // run commands until we receive a request to restart. This kills
 // the process and transitions to SUnbooted.
-func (s *SlaveNode) doReadyState() string { // -> SUnbooted
+func (s *SlaveNode) doReadyState() string { // -> {SUnbooted, SCrashed}
 	s.hasSuccessfullyBooted = true
 
 	// If we have a queued restart, service that rather than booting
@@ -245,6 +245,8 @@ func (s *SlaveNode) doReadyState() string { // -> SUnbooted
 	default:
 	}
 
+	processStatus := s.waitForProcess()
+
 	for {
 		select {
 		case <-s.needsRestart:
@@ -254,6 +256,13 @@ func (s *SlaveNode) doReadyState() string { // -> SUnbooted
 			s.bootSlave(slave)
 		case request := <-s.commandBootRequests:
 			s.bootCommand(request)
+		case code := <-processStatus:
+			if code == -1 {
+				s.Error = fmt.Sprintf("child process exited unexpectedly with status %d", code)
+			} else {
+				s.Error = "child process exited unexpectedly with non-zero status"
+			}
+			return SCrashed
 		}
 	}
 }
@@ -350,6 +359,35 @@ func (s *SlaveNode) bootCommand(request *CommandRequest) {
 	fileName := strconv.Itoa(rand.Int())
 	commandFile := os.NewFile(uintptr(commandFD), fileName)
 	request.Retchan <- &CommandReply{s.state, commandFile}
+}
+
+func (s *SlaveNode) waitForProcess() <-chan int {
+	s.L.Lock()
+	defer s.L.Unlock()
+
+	result := make(chan int)
+	proc, err := os.FindProcess(s.pid)
+	if err != nil {
+		// Per the Golang docs, this should never return an error on
+		// the Unix systems Zeus supports.
+		panic(err)
+	}
+
+	go func() {
+		state, err := proc.Wait()
+		if err != nil {
+			s.trace("error waiting for child process to exit: %v", err)
+			result <- -1
+		} else if state.Success() {
+			result <- 0
+		} else if status, ok := state.Sys().(syscall.WaitStatus); ok {
+			result <- int(status)
+		} else {
+			result <- -1
+		}
+	}()
+
+	return result
 }
 
 func (s *SlaveNode) ForceKill() {


### PR DESCRIPTION
Currently nodes do not monitor whether their processes exit. A node will remain marked as "running" until it is reloaded, even if the underlying process dies. Instead, it should be marked as crashed. I believe this is true even if the underlying process exits with a success code -- Zeus never expects its processes to die.