### PR TITLE
Cleanup Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,5 @@ env:
   - USE_RUBY=2.2.3
 before_install:
   - rvm use $USE_RUBY --install --fuzzy
-install:
-  - make dev_bootstrap
-  - make rubygem/lib/zeus/version.rb
 script:
-  - RAILS_ENV="" make test-go
-  - make build-linux
-  - make rubygem/lib/zeus/version.rb && cd rubygem && bundle install --without development && bin/rspec spec
+  - RAILS_ENV="" make


### PR DESCRIPTION
* Use real targets so that Make will correctly handle rebuilding on changes.
* Incorporate linux/darwin logic into the Makefile to avoid duplicate targets that humans need to choose between.
* Remove `dev_bootstrap` so that `make` works out-of-the-box for new developers.
* Create a single `make test` command to run all tests.