### PR TITLE
Remove find_in_load_path

### DIFF
--- a/rubygem/lib/zeus/load_tracking.rb
+++ b/rubygem/lib/zeus/load_tracking.rb
@@ -35,27 +35,16 @@ module Zeus
       # then gets added to $LOADED_FEATURES array.
       def add_feature(file)
         full_path = File.expand_path(file)
+        return unless File.exist?(full_path)
 
-        if find_in_load_path(full_path) || File.exist?(full_path)
-          add_extra_feature(full_path)
-        end
+        $untracked_features ||= []
+        $untracked_features << full_path
       end
 
       # $LOADED_FEATURES global variable is used internally by Rubygems
       def all_features
         untracked = defined?($untracked_features) ? $untracked_features : []
         $LOADED_FEATURES + untracked
-      end
-
-      private
-
-      def add_extra_feature(path)
-        $untracked_features ||= []
-        $untracked_features << path
-      end
-
-      def find_in_load_path(file_path)
-        $LOAD_PATH.detect { |path| path == file_path }
       end
     end
   end


### PR DESCRIPTION
`find_in_load_path` was introduced in a very early version of Zeus. It allowed you to pass a path to `add_feature` that is relative to something in the `$LOAD_PATH`, rather than an absolute path.  This made the semantics of `add_feature` equivalent to `require`. ba7c7d7a3018319d86a8c685c72f3476ff75a31f attempted to simplify this logic but actually broke it completely. The current code searches for the file in the `$LOAD_PATH`, which contains a list of directories so no Ruby filename will match. Things in the `$LOAD_PATH` should always exist so it's also duplicative of the `File.exist?` check.

We could roll back ba7c7d7a3018319d86a8c685c72f3476ff75a31f, but since no one has reported an issue, I suspect that code is not being relied on.  That makes some sense since it predates most Zeus adoption and the use of `$LOADED_FEATURES` to automatically handle most load
tracking. Instead, we can remove this feature entirely and substantially speed up tracking of files. Tracking our entire codebase on my laptop takes ~300-400ms before this diff and 80-150ms after.