### PR TITLE
Add support for delayed feature loading

### DIFF
--- a/rubygem/lib/zeus/load_tracking.rb
+++ b/rubygem/lib/zeus/load_tracking.rb
@@ -25,26 +25,22 @@ module Zeus
         end
 
         new_features = all_features + err_features - old_features
-        new_features.uniq!
 
         [new_features, err]
       end
 
-      # Check the load path first to see if the file getting loaded is already
-      # loaded. Otherwise, add the file to the $untracked_features array which
-      # then gets added to $LOADED_FEATURES array.
       def add_feature(file)
-        full_path = File.expand_path(file)
-        return unless File.exist?(full_path)
+        add_features([file])
+      end
 
-        $untracked_features ||= []
-        $untracked_features << full_path
+      def add_features(files)
+        files = files.map { |f| File.expand_path(f) }.select { |f| File.exist?(f) }
+        Zeus.notify_features(files)
       end
 
       # $LOADED_FEATURES global variable is used internally by Rubygems
       def all_features
-        untracked = defined?($untracked_features) ? $untracked_features : []
-        $LOADED_FEATURES + untracked
+        Set.new($LOADED_FEATURES.dup)
       end
     end
   end

--- a/rubygem/spec/assets/boot.rb
+++ b/rubygem/spec/assets/boot.rb
@@ -1,0 +1,2 @@
+# This is a single ruby file that doesn't do anything for testing Zeus
+# load tracking during boot.

--- a/rubygem/spec/assets/boot_delayed.rb
+++ b/rubygem/spec/assets/boot_delayed.rb
@@ -1,0 +1,2 @@
+# This is a single ruby file that doesn't do anything for testing Zeus
+# load tracking after boot.

--- a/rubygem/spec/load_tracking_spec.rb
+++ b/rubygem/spec/load_tracking_spec.rb
@@ -1,4 +1,4 @@
-require 'zeus/load_tracking'
+require 'zeus'
 
 describe "Zeus::LoadTracking" do
   let(:test_filename) { __FILE__ }
@@ -6,55 +6,44 @@ describe "Zeus::LoadTracking" do
 
   class MyError < StandardError; end
 
+  def expect_to_load(expect_features, expect_err=NilClass)
+    new_files, err = Zeus::LoadTracking.features_loaded_by do
+      yield
+    end
+
+    expect(new_files.sort).to eq(expect_features.sort)
+    expect(err).to be_instance_of(expect_err)
+  end
+
+  def expand_asset_path(path)
+    File.join(__dir__, 'assets', path)
+  end
+
   describe '.add_feature' do
-    context 'already in load path' do
-      before do
-        # add the dir path of the tempfile to LOAD_PATH
-        $LOAD_PATH  << test_dirname
-      end
+    it 'tracks full filepath' do
+      relative_path = Pathname.new(test_filename).relative_path_from(Pathname.new(Dir.pwd)).to_s
 
-      after { $LOAD_PATH.delete test_dirname }
-
-      it 'adds full filepath to $untracked_features' do
-        Zeus::LoadTracking.add_feature(test_filename)
-
-        expect($untracked_features).to include(__dir__ + "/load_tracking_spec.rb")
+      expect(Zeus).to receive(:notify_features).with([test_filename])
+      expect_to_load([]) do
+        Zeus::LoadTracking.add_feature(relative_path)
       end
     end
 
-    context 'not in load path' do
-      it 'adds full filepath to $untracked_features' do
-        Zeus::LoadTracking.add_feature(test_filename)
+    it 'tracks loads' do
+      target = expand_asset_path('load.rb')
 
-        expect($untracked_features).to include(__dir__ + "/load_tracking_spec.rb")
+      expect(Zeus).to receive(:notify_features).with([target])
+      expect_to_load([]) do
+        load(target)
       end
     end
 
-    context '.features_loaded_by' do
-      it 'returns list of new files loaded when block executes' do
-        new_files, = Zeus::LoadTracking.features_loaded_by do
-          $untracked_features << "an_untracked_feature.rb"
-        end
-
-        expect(new_files).to eq(["an_untracked_feature.rb"])
-      end
+    it 'does not error outside a tracking block without Zeus configured' do
+      Zeus::LoadTracking.add_feature(test_filename)
     end
   end
 
   describe '.features_loaded_by' do
-    def expect_to_load(expect_features, expect_err=NilClass)
-      new_files, err = Zeus::LoadTracking.features_loaded_by do
-        yield
-      end
-
-      expect(new_files.sort).to eq(expect_features.sort)
-      expect(err).to be_instance_of(expect_err)
-    end
-
-    def expand_asset_path(path)
-      File.join(__dir__, 'assets', path)
-    end
-
     context 'loading valid code' do
       it 'tracks successful require_relative' do
         expect_to_load([expand_asset_path('require_relative.rb')]) do
@@ -67,35 +56,29 @@ describe "Zeus::LoadTracking" do
           require expand_asset_path('require')
         end
       end
-
-      it 'tracks loads' do
-        expect_to_load([expand_asset_path('load.rb')]) do
-          load expand_asset_path('load.rb')
-        end
-      end
     end
 
     context 'loading invalid code' do
       it 'tracks requires that raise a SyntaxError' do
-        expect_to_load([expand_asset_path('invalid_syntax.rb')], SyntaxError) do
+        expect_to_load([test_filename, expand_asset_path('invalid_syntax.rb')], SyntaxError) do
           require expand_asset_path('invalid_syntax')
         end
       end
 
       it 'tracks requires that raise a RuntimeError' do
-        expect_to_load([expand_asset_path('runtime_error.rb')], RuntimeError) do
+        expect_to_load([test_filename, expand_asset_path('runtime_error.rb')], RuntimeError) do
           require expand_asset_path('runtime_error')
         end
       end
 
       it 'tracks requires that exit' do
-        expect_to_load([expand_asset_path('exit.rb')], SystemExit) do
+        expect_to_load([test_filename, expand_asset_path('exit.rb')], SystemExit) do
           require expand_asset_path('exit')
         end
       end
 
       it 'tracks requires that throw in a method call' do
-        expect_to_load([expand_asset_path('raise.rb')], MyError) do
+        expect_to_load([test_filename, expand_asset_path('raise.rb')], MyError) do
           require expand_asset_path('raise')
           raise_it(MyError)
         end

--- a/rubygem/spec/zeus_spec.rb
+++ b/rubygem/spec/zeus_spec.rb
@@ -1,0 +1,85 @@
+require 'zeus'
+
+describe Zeus do
+  class MyTestPlan < Zeus::Plan
+    def self.mutex
+      @mutex ||= Mutex.new
+    end
+
+    def self.boot
+      require_relative 'assets/boot'
+      Thread.new do
+        mutex.synchronize do
+          Zeus::LoadTracking.add_feature(File.join(__dir__, 'assets', 'boot_delayed.rb'))
+        end
+      end
+    end
+  end
+
+  Zeus.plan = MyTestPlan
+
+  before do
+    MyTestPlan.mutex.lock
+  end
+
+  after do
+    MyTestPlan.mutex.unlock if MyTestPlan.mutex.locked?
+  end
+
+  context 'booting' do
+    before do
+      # Don't reopen STDOUT
+      Zeus.dummy_tty = true
+    end
+
+    it 'boots and tracks features' do
+      master_r, master_w = UNIXSocket.pair(Socket::SOCK_STREAM)
+      ENV['ZEUS_MASTER_FD'] = master_w.to_i.to_s
+
+      thr = Thread.new do
+        begin
+          Zeus.go
+        rescue Interrupt
+          return
+        rescue => e
+          STDERR.puts "Zeus terminated with exception: #{e.message}"
+          STDERR.puts e.backtrace.map {|line| " #{line}"}
+        end
+      end
+
+      begin
+        # Receive the control IO and start message
+        ctrl_io = master_r.recv_io(UNIXSocket)
+        begin
+          # We use recv instead of readline on the UNIXSocket to avoid
+          # converting it to a buffered reader. That seems to interact
+          # badly with passing file descriptors around on Linux.
+          proc_msg = "P:#{Process.pid}:0:boot\0"
+          expect(ctrl_io.recv(proc_msg.length)).to eq(proc_msg)
+
+          feature_io = ctrl_io.recv_io
+
+          ready_msg = "R:OK\0"
+          expect(ctrl_io.recv(ready_msg.length)).to eq(ready_msg)
+          begin
+            # We should receive the synchronously required feature immediately
+            expect(feature_io.readline).to eq(File.join(__dir__, 'assets', 'boot.rb') + "\n")
+
+            # We should receive the delayed feature after unlocking its mutex
+            MyTestPlan.mutex.unlock
+            expect(feature_io.readline).to eq(File.join(__dir__, 'assets', 'boot_delayed.rb') + "\n")
+          ensure
+            feature_io.close
+          end
+        ensure
+          ctrl_io.close
+        end
+      ensure
+        thr.raise(Interrupt.new)
+      end
+    end
+
+    it 'tracks features after booting has completed' do
+    end
+  end
+end


### PR DESCRIPTION
Zeus currently only reports features once when the action it executes completes. Many of our actions spawn long running server processes in a new thread. These can subsequently require new files (especially if you're using an autoloader). 

This PR adds support for calling `Zeus.notify_features` *after* an action has run to report additional features to Zeus.

[An alternative implementation](https://github.com/burke/zeus/compare/andrew-delayed-features-simple) would leave `LoadTracking` as-is and ask consumer to call `Zeus.notify_features` to load delayed features. This avoids a circular dependency between `Zeus` and `Zeus::LoadTracking` but I believe would be the first instance of expecting client code to call a method on `Zeus`. 