### PR TITLE
Fix debouncing logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.7
 os:
   - linux
   - osx
@@ -8,6 +8,15 @@ env:
   - USE_RUBY=2.0.0-p647
   - USE_RUBY=2.1.7
   - USE_RUBY=2.2.3
+# OS X builds are slow and heavily rate limited. Ruby should behave similarly
+# across platforms so we sacrifice testing multiple Ruby versions in favor of
+# faster build times.
+matrix:
+  exclude:
+    - os: osx
+      env: USE_RUBY=2.0.0-p647
+    - os: osx
+      env: USE_RUBY=2.1.7
 before_install:
   - rvm use $USE_RUBY --install --fuzzy
 script:

--- a/go/filemonitor/filelistener.go
+++ b/go/filemonitor/filelistener.go
@@ -11,7 +11,7 @@ import (
 )
 
 type fileListener struct {
-	gatheringMonitor
+	fileMonitor
 	netListener net.Listener
 	connections map[net.Conn]chan string
 	stop        chan struct{}

--- a/go/filemonitor/filelistener_test.go
+++ b/go/filemonitor/filelistener_test.go
@@ -25,7 +25,7 @@ func TestFileListener(t *testing.T) {
 	}
 
 	slog.SetTraceLogger(slog.NewTraceLogger(os.Stderr))
-	fl := filemonitor.NewFileListener(filemonitor.DefaultFileChangeDelay, ln)
+	fl := filemonitor.NewFileListener(fileChangeDelay, ln)
 	defer fl.Close()
 
 	// We should be able to add a file without connecting anything

--- a/go/filemonitor/filemonitor_fsnotify.go
+++ b/go/filemonitor/filemonitor_fsnotify.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fsnotifyMonitor struct {
-	gatheringMonitor
+	fileMonitor
 	watcher *fsnotify.Watcher
 }
 


### PR DESCRIPTION
The file monitor fileChangeDelay parameter should act to debounce change events. It should only report an event when it has not seen a new change for at least fileChangeDelay. Currently Zeus implements throttling as opposed to debouncing -- it sends an event at most every fileChangeDelay but does not wait for the event stream to quiesce before sending the first event. This can result in reloading code in the midst of an operation such as an rsync or git change.