### PR TITLE
Do not log unexpected process kills to STDOUT

### DIFF
--- a/go/processtree/slavenode.go
+++ b/go/processtree/slavenode.go
@@ -119,7 +119,7 @@ func (s *SlaveNode) SlaveWasInitialized(pid, parentPid int, usock *unixsocket.Us
 	s.L.Lock()
 	if !s.ReportBootEvent() {
 		s.forceKillPid(pid)
-		slog.ErrorString(fmt.Sprintf("Unexpected process %d with parent %d for slave %q was killed", pid, parentPid, s.Name))
+		s.trace("Unexpected process %d with parent %d for slave %q was killed", pid, parentPid, s.Name)
 	} else {
 		s.wipe()
 		s.pid = pid


### PR DESCRIPTION
There's a race condition in SlaveNode in which we see a stale child process boot and need to kill it:
* Send a request to boot a child process.
* File change causes us to kill the parent.
* Child boots but is associated with an old parent so we kill it.

This is harmless but currently logs a scary error to STDOUT. We should send this to the trace log instead.

r? @ptarjan