### PR TITLE
Log changed files during restarts

### DIFF
--- a/go/processtree/processtree.go
+++ b/go/processtree/processtree.go
@@ -70,6 +70,7 @@ var restartMutex sync.Mutex
 func (tree *ProcessTree) RestartNodesWithFeatures(files []string) {
 	restartMutex.Lock()
 	defer restartMutex.Unlock()
+	tree.Root.trace("%d files changed, beginning with %q", len(files), files[0])
 	tree.Root.restartNodesWithFeatures(tree, files)
 }
 
@@ -77,6 +78,7 @@ func (tree *ProcessTree) RestartNodesWithFeatures(files []string) {
 func (node *SlaveNode) restartNodesWithFeatures(tree *ProcessTree, files []string) {
 	for _, file := range files {
 		if node.HasFeature(file) {
+			node.trace("restarting for %q", file)
 			node.RequestRestart()
 			return
 		}

--- a/go/processtree/slavemonitor.go
+++ b/go/processtree/slavemonitor.go
@@ -61,7 +61,9 @@ func StartSlaveMonitor(tree *ProcessTree, fileChanges <-chan []string, done chan
 			case fd := <-registeringFds:
 				go monitor.slaveDidBeginRegistration(fd)
 			case files := <-fileChanges:
-				tree.RestartNodesWithFeatures(files)
+				if len(files) > 0 {
+					tree.RestartNodesWithFeatures(files)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
This adds logging for file changes that trigger restarts. It should help with debugging cases where Zeus appeared not to restart correctly. Observed the new log output by running the tests verbosely:
```
...
2016/08/24 17:22:31.188117 [/Users/andrew/code/go/src/github.com/burke/zeus/go/processtree/processtree.go:71] boot/(15743) 2 files changed, beginning with "/private/var/folders/z9/60xl3r5s7y7_z4tr62pyplh00000gn/T/zeus_test054172267/code.rb"
2016/08/24 17:22:31.188156 [/Users/andrew/code/go/src/github.com/burke/zeus/go/processtree/processtree.go:79] data/(15769) restarting for "/private/var/folders/z9/60xl3r5s7y7_z4tr62pyplh00000gn/T/zeus_test054172267/data.yaml"
2016/08/24 17:22:31.188175 [/Users/andrew/code/go/src/github.com/burke/zeus/go/processtree/processtree.go:79] code/(15770) restarting for "/private/var/folders/z9/60xl3r5s7y7_z4tr62pyplh00000gn/T/zeus_test054172267/code.rb"
2016/08/24 17:22:32.188458 [/Users/andrew/code/go/src/github.com/burke/zeus/go/processtree/slavenode.go:142] code/(no PID) entering state SUnbooted
2016/08/24 17:22:32.188460 [/Users/andrew/code/go/src/github.com/burke/zeus/go/processtree/slavenode.go:142] data/(no PID) entering state SUnbooted
...
```

r? @russelldavis (this was about the only working idea that came from my attempt to fix debouncing further)