### PR TITLE
Fix Travis by removing excess Gem mention

### DIFF
--- a/vagrant/Gemfile
+++ b/vagrant/Gemfile
@@ -8,7 +8,3 @@ gem 'rake', group: :gem_build_tools
 group :development do
   gem "vagrant"
 end
-
-group :plugins do
-  gem "vagrant-zeus", path: "."
-end


### PR DESCRIPTION
A gem shouldn't need to mention itself in its Gemfile and this seems to be causing problems with our Travis CI builds.