### PR TITLE
Add a few more essential set up instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ A: No. You can, but running `bundle exec zeus` instead of `zeus` adds precious s
 It is common to see tests running twice when starting out with Zeus. If you see your tests/specs running twice, you should try disabling `require 'rspec/autotest'` and `require 'rspec/autorun'` (for RSpec), or `require 'minitest/autorun'` (for Minitest). (see [#134](https://github.com/burke/zeus/issues/134) for more information).
 
 
+## Set up 
+
+In your Rails app's directory initialize zeus:
+
+    zeus init
+
+which will create two files that should be added to your `.gitignore` (or globally in `~/.gitignore`)
+
+    custom_plan.rb
+    zeus.json
+
+Force the test environment: In `spec/spec_helper.rb`, change:
+
+
+    ENV['RAILS_ENV'] ||= 'test'
+
+To:
+
+    ENV['RAILS_ENV'] = 'test'
+
+_More helpful set up hints at [this very nice guide put together by Thoughtbot](https://robots.thoughtbot.com/improving-rails-boot-time-with-zeus)_
+
 ## Usage
 
 Start the server:

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ A: No. You can, but running `bundle exec zeus` instead of `zeus` adds precious s
 It is common to see tests running twice when starting out with Zeus. If you see your tests/specs running twice, you should try disabling `require 'rspec/autotest'` and `require 'rspec/autorun'` (for RSpec), or `require 'minitest/autorun'` (for Minitest). (see [#134](https://github.com/burke/zeus/issues/134) for more information).
 
 
-## Set up 
+## Rails Set up 
 
-In your Rails app's directory initialize zeus:
+In your app's directory initialize zeus:
 
     zeus init
 
-which will create two files that should be added to your `.gitignore` (or globally in `~/.gitignore`)
+which will create two files
 
     custom_plan.rb
     zeus.json
 
-Force the test environment: In `spec/spec_helper.rb`, change:
+Force the test environment: In `test/test_helper.rb' (or `spec/spec_helper.rb` if using RSpec), change:
 
 
     ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
I installed zeus this afternoon and missed the `zeus init` step and a couple other set up steps that I found [at this Thoughtbot article](https://robots.thoughtbot.com/improving-rails-boot-time-with-zeus). They seemed like they should be included in the README so I added them. 

First open source pull request, sorry in advance if I'm missing something!
