### PR TITLE
Handle errors reading from socket during boot gracefully

### DIFF
--- a/go/processtree/slavenode.go
+++ b/go/processtree/slavenode.go
@@ -209,8 +209,14 @@ func (s *SlaveNode) doBootingState() string { // -> {SCrashed, SReady}
 	// Note we don't hold the mutex while waiting for the action to execute.
 	msg, err := s.socket.ReadMessage()
 	if err != nil {
-		slog.Error(err)
+		s.L.Lock()
+		defer s.L.Unlock()
+		s.Error = err.Error()
+		slog.ErrorString("[" + s.Name + "] " + err.Error())
+
+		return SCrashed
 	}
+
 	s.trace("received action message")
 	s.L.Lock()
 	defer s.L.Unlock()


### PR DESCRIPTION
Currently when Zeus receives any error reading from the command socket while waiting for a process to boot, it logs the error and then tries to parse the message anyway. Since the message shouldn't be valid when there's an error, we should instead enter an `SCrashed` state immediately. We could be throwing away useful debugging information bufferred from an earlier read but I don't think that'll actually happen in the existing Zeus code.