### PR TITLE
Log zeus error to stderr

### DIFF
--- a/go/shinylog/shinylog.go
+++ b/go/shinylog/shinylog.go
@@ -13,18 +13,32 @@ import (
 type ShinyLogger struct {
 	mu             sync.Mutex
 	happyLogger    log.Logger
+	errorLogger    log.Logger
 	sadLogger      log.Logger
 	suppressOutput bool
 	disableColor   bool
+}
+
+type loggerOptions struct {
+	isError, printNewline, includeLocation bool
+}
+
+var errorOptions loggerOptions
+var outOptions loggerOptions
+
+func init() {
+	errorOptions = loggerOptions{isError: true, printNewline: true, includeLocation: true}
+	outOptions = loggerOptions{isError: false, printNewline: true, includeLocation: false}
 }
 
 func NewShinyLogger(out, err interface {
 	io.Writer
 }) *ShinyLogger {
 	happyLogger := log.New(out, "", 0)
+	errorLogger := log.New(err, "", 0)
 	sadLogger := log.New(err, "", log.Lshortfile)
 	var mu sync.Mutex
-	return &ShinyLogger{mu, *happyLogger, *sadLogger, false, false}
+	return &ShinyLogger{mu, *happyLogger, *errorLogger, *sadLogger, false, false}
 }
 
 func NewTraceLogger(out interface {
@@ -78,6 +92,7 @@ func Error(err error) bool                { return DefaultLogger().Error(err) }
 func FatalError(err error)                { DefaultLogger().FatalError(err) }
 func FatalErrorString(msg string)         { DefaultLogger().FatalErrorString(msg) }
 func ErrorString(msg string) bool         { return DefaultLogger().ErrorString(msg) }
+func StdErrorString(msg string) bool      { return DefaultLogger().StdErrorString(msg) }
 func Red(msg string) bool                 { return DefaultLogger().Red(msg) }
 func Green(msg string) bool               { return DefaultLogger().Green(msg) }
 func Brightgreen(msg string) bool         { return DefaultLogger().Brightgreen(msg) }
@@ -108,11 +123,11 @@ func (l *ShinyLogger) DisableColor() {
 }
 
 func (l *ShinyLogger) Colorized(msg string) (printed bool) {
-	return l.colorized(3, msg, false, true)
+	return l.colorized(3, msg, outOptions)
 }
 
 func (l *ShinyLogger) ColorizedSansNl(msg string) (printed bool) {
-	return l.colorized(3, msg, false, false)
+	return l.colorized(3, msg, loggerOptions{isError: false, printNewline: false, includeLocation: false})
 }
 
 // If we send SIGTERM rather than explicitly exiting,
@@ -124,45 +139,49 @@ func terminate() {
 }
 
 func (l *ShinyLogger) FatalErrorString(msg string) {
-	l.colorized(3, "{red}"+msg, true, true)
+	l.colorized(3, "{red}"+msg, errorOptions)
 	terminate()
 }
 
 func (l *ShinyLogger) FatalError(err error) {
-	l.colorized(3, "{red}"+err.Error(), true, true)
+	l.colorized(3, "{red}"+err.Error(), errorOptions)
 	terminate()
 }
 
 func (l *ShinyLogger) Error(err error) bool {
-	return l.colorized(3, "{red}"+err.Error(), true, true)
+	return l.colorized(3, "{red}"+err.Error(), errorOptions)
 }
 
 func (l *ShinyLogger) ErrorString(msg string) bool {
-	return l.colorized(3, "{red}"+msg, true, true)
+	return l.colorized(3, "{red}"+msg, errorOptions)
+}
+
+func (l *ShinyLogger) StdErrorString(msg string) bool {
+	return l.colorized(3, "{red}"+msg, loggerOptions{isError: true, printNewline: true, includeLocation: false})
 }
 
 func (l *ShinyLogger) Red(msg string) bool {
-	return l.colorized(3, "{red}"+msg, false, true)
+	return l.colorized(3, "{red}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) Green(msg string) bool {
-	return l.colorized(3, "{green}"+msg, false, true)
+	return l.colorized(3, "{green}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) Brightgreen(msg string) bool {
-	return l.colorized(3, "{brightgreen}"+msg, false, true)
+	return l.colorized(3, "{brightgreen}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) Yellow(msg string) bool {
-	return l.colorized(3, "{yellow}"+msg, false, true)
+	return l.colorized(3, "{yellow}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) Blue(msg string) bool {
-	return l.colorized(3, "{blue}"+msg, false, true)
+	return l.colorized(3, "{blue}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) Magenta(msg string) bool {
-	return l.colorized(3, "{magenta}"+msg, false, true)
+	return l.colorized(3, "{magenta}"+msg, outOptions)
 }
 
 func (l *ShinyLogger) formatColors(msg string) string {
@@ -186,7 +205,7 @@ func (l *ShinyLogger) formatColors(msg string) string {
 	return msg
 }
 
-func (l *ShinyLogger) colorized(callDepth int, msg string, isError bool, printNewline bool) (printed bool) {
+func (l *ShinyLogger) colorized(callDepth int, msg string, options loggerOptions) (printed bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -196,15 +215,18 @@ func (l *ShinyLogger) colorized(callDepth int, msg string, isError bool, printNe
 		if l == DefaultLogger() {
 			callDepth += 1 // this was called through a proxy method
 		}
-		if isError {
-			l.sadLogger.Output(callDepth, msg+reset)
+		if options.isError {
+			if options.includeLocation {
+				l.sadLogger.Output(callDepth, msg+reset)
+			} else {
+				l.errorLogger.Output(callDepth, msg+reset)
+			}
 		} else {
-			if printNewline {
+			if options.printNewline {
 				fmt.Println(msg + reset)
 			} else {
 				fmt.Print(msg + reset)
 			}
-			//l.happyLogger.Output(callDepth, msg+reset)
 		}
 	}
 	return !l.suppressOutput

--- a/go/shinylog/shinylog.go
+++ b/go/shinylog/shinylog.go
@@ -24,11 +24,13 @@ type loggerOptions struct {
 }
 
 var errorOptions loggerOptions
-var outOptions loggerOptions
+var stdoutOptions loggerOptions
+var stderrOptions loggerOptions
 
 func init() {
 	errorOptions = loggerOptions{isError: true, printNewline: true, includeLocation: true}
-	outOptions = loggerOptions{isError: false, printNewline: true, includeLocation: false}
+	stdoutOptions = loggerOptions{isError: false, printNewline: true, includeLocation: false}
+	stderrOptions = loggerOptions{isError: false, printNewline: true, includeLocation: false}
 }
 
 func NewShinyLogger(out, err interface {
@@ -123,7 +125,7 @@ func (l *ShinyLogger) DisableColor() {
 }
 
 func (l *ShinyLogger) Colorized(msg string) (printed bool) {
-	return l.colorized(3, msg, outOptions)
+	return l.colorized(3, msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) ColorizedSansNl(msg string) (printed bool) {
@@ -157,31 +159,31 @@ func (l *ShinyLogger) ErrorString(msg string) bool {
 }
 
 func (l *ShinyLogger) StdErrorString(msg string) bool {
-	return l.colorized(3, "{red}"+msg, loggerOptions{isError: true, printNewline: true, includeLocation: false})
+	return l.colorized(3, "{red}"+msg, stderrOptions)
 }
 
 func (l *ShinyLogger) Red(msg string) bool {
-	return l.colorized(3, "{red}"+msg, outOptions)
+	return l.colorized(3, "{red}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) Green(msg string) bool {
-	return l.colorized(3, "{green}"+msg, outOptions)
+	return l.colorized(3, "{green}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) Brightgreen(msg string) bool {
-	return l.colorized(3, "{brightgreen}"+msg, outOptions)
+	return l.colorized(3, "{brightgreen}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) Yellow(msg string) bool {
-	return l.colorized(3, "{yellow}"+msg, outOptions)
+	return l.colorized(3, "{yellow}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) Blue(msg string) bool {
-	return l.colorized(3, "{blue}"+msg, outOptions)
+	return l.colorized(3, "{blue}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) Magenta(msg string) bool {
-	return l.colorized(3, "{magenta}"+msg, outOptions)
+	return l.colorized(3, "{magenta}"+msg, stdoutOptions)
 }
 
 func (l *ShinyLogger) formatColors(msg string) string {

--- a/go/zerror/zerror.go
+++ b/go/zerror/zerror.go
@@ -34,7 +34,7 @@ func Error(msg string) {
 }
 
 func ErrorCantConnectToMaster() {
-	slog.Red("Can't connect to master. Run {yellow}zeus start{red} first.\r")
+	slog.StdErrorString("Can't connect to master. Run {yellow}zeus start{red} first.\r")
 }
 
 func ErrorConfigCommandCouldntStart(msg, output string) {


### PR DESCRIPTION
When zeus has an error it is quite inconvinient to have it written to stdout as
this easily hides problems. To resolve this we allow `shinylog` to log to
`stderr` for strings. As those are user facing error we want to hide the
implementation detail of go so don't log error locations as they are most likely
not helpful to the end user.

fixes #612 