### PR TITLE
Seperate stdout and stderr

### DIFF
--- a/go/clienthandler/clienthandler.go
+++ b/go/clienthandler/clienthandler.go
@@ -71,6 +71,9 @@ func handleClientConnection(tree *processtree.ProcessTree, usock *unixsocket.Uso
 	clientFile, err := receiveTTY(usock, err)
 	defer clientFile.Close()
 
+	stderrFile, err := receiveTTY(usock, err)
+	defer stderrFile.Close()
+
 	if err == nil && slaveNode.Error != "" {
 		writeStacktrace(usock, slaveNode, clientFile)
 		return
@@ -88,7 +91,10 @@ func handleClientConnection(tree *processtree.ProcessTree, usock *unixsocket.Uso
 
 	err = sendClientPidAndArgumentsToCommand(commandUsock, clientPid, argCount, argFD, err)
 
+	// send stdout to use
 	err = sendTTYToCommand(commandUsock, clientFile, err)
+	// send stderr to use
+	err = sendTTYToCommand(commandUsock, stderrFile, err)
 
 	cmdPid, err := receivePidFromCommand(commandUsock, err)
 

--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -86,7 +86,7 @@ func main() {
 			if args[0] == name {
 				// Don't confuse the master by sending *full* args to
 				// it; just those that are not zeus-specific.
-				os.Exit(zeusclient.Run(args, os.Stdin, os.Stdout))
+				os.Exit(zeusclient.Run(args, os.Stdin, os.Stdout, os.Stderr))
 			}
 		}
 

--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -143,13 +143,14 @@ module Zeus
         $0 = "zeus command: #{identifier}"
 
         plan.after_fork
-        client_terminal = local.recv_io
+        remote_stdin_stdout = local.recv_io
+        remote_stderr = local.recv_io
         local.write "P:#{Process.pid}:#{@parent_pid}:\0"
         local.close
 
-        $stdin.reopen(client_terminal)
-        $stdout.reopen(client_terminal)
-        $stderr.reopen(client_terminal)
+        $stdin.reopen(remote_stdin_stdout)
+        $stdout.reopen(remote_stdin_stdout)
+        $stderr.reopen(remote_stderr)
         ARGV.replace(arguments)
 
         plan.send(identifier)


### PR DESCRIPTION
It is often helpful to have seperate streams for stdout and stderr especially
when grepping stdout I still want to see errors on stderr.

- [x] cleanup code to remove duplication
- [x] squash all the commit