### PR TITLE
re-support rspec 2

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -204,7 +204,11 @@ module Zeus
       # RSpec suite by default.
       if using_rspec?(argv)
         ARGV.replace(argv)
-        RSpec::Core::Runner.invoke
+        if RSpec::Core::Runner.respond_to?(:invoke)
+          RSpec::Core::Runner.invoke
+        else
+          RSpec::Core::Runner.run(argv)
+        end
       else
         require 'minitest/autorun' if using_minitest?
         # Minitest and old Test::Unit


### PR DESCRIPTION
## Description of Problem
`zeus rspec` fails for rspec 2 since the invoke method does not exist on RSpec::Core::Runner until rspec 3

## System details

* **`uname -a`**: Darwin I.local 15.6.0 Darwin Kernel Version 15.6.0: Wed Nov  2 20:30:56 PDT 2016; root:xnu-3248.60.11.1.2~2/RELEASE_X86_64 x86_64


* **`ruby -v`**: 
ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-darwin14.0]

## Steps to Reproduce

1) `zeus start` in a rails project with rails 2 

2) `zeus rspec`

## Observed Behavior
```
/usr/local/var/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/zeus-0.15.12/lib/zeus/rails.rb:207:in `test': undefined method `invoke' for RSpec::Core::Runner:Class (NoMethodError)
```
## Expected Behavior

* tests run