### PR TITLE
run rspec specs by default

### DIFF
--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -204,6 +204,8 @@ module Zeus
       # RSpec suite by default.
       if using_rspec?(argv)
         ARGV.replace(argv)
+        # if no directory is given, run the default spec directory
+        argv << "spec" if argv.empty?
         if RSpec::Core::Runner.respond_to?(:invoke)
           RSpec::Core::Runner.invoke
         else


### PR DESCRIPTION
When running `zeus rspec` without any arguments it seems sensible to expect zeus
to run all the specs, same as `zeus rspec spec`. This behaviour is the same as
 `<= 0.15.4`.

Fixes #595 