### PR TITLE
[issue-431] simple status output format

### DIFF
--- a/emacs/README.md
+++ b/emacs/README.md
@@ -1,0 +1,32 @@
+# Zeus.el
+
+Package to run zeus commands and manage the zeus server from inside Emacs
+
+## Installation
+
+Put `zeus.el` inside your load path (`~/.emacs.d/site-lisp` for example)
+
+```elisp
+(setq site-lisp-dir (expand-file-name "site-lisp" user-emacs-directory))
+(add-to-list 'load-path site-lisp-dir)
+(require 'zeus)
+```
+## Usage
+
+### `zeus-start` command
+
+Starts a new zeus process in the current directory, zeus needs to support
+`--simple-status` for this to work.
+
+### `zeus-stop` command
+
+Stop the process created via `zeus-start`
+
+### `zeus-run-command` command
+
+run an available zeus command in the current directory, with additional
+arguments as requested. With `C-u` prefix this will be run as the compile
+command, otherwise it will be run in a new buffer. 
+
+Commands are completed using `ido` completion if available.
+

--- a/emacs/zeus.el
+++ b/emacs/zeus.el
@@ -1,0 +1,66 @@
+;;; zeus.el -- Minor mode for zeus application preloader
+
+;;; Commentary:
+;;
+;; Implements `zeus-mode' for the zeus application preloader. This includes
+;; support to start, stop and run commands against a running zeus server.
+
+(require 's)
+(require 'json)
+(require 'cl)
+(require 'dash)
+
+(defcustom zeus-mode-completion-use-ido
+  "Use ido mode for completion of zeus commands"
+  t)
+
+(defvar *zeus-server-process*
+  "zeus server process buffer"
+  nil)
+
+(defun zeus--run (name buffer-name command &optional options)
+  "Run a zeus command returning the running process buffer"
+  (let ((zeus-command (s-join " " (list "zeus" (s-join " " options) command))))
+    (process-buffer (start-process-shell-command name buffer-name zeus-command))))
+
+(defun zeus--available-commands ()
+  (let* ((zeus-json (json-read-from-string
+                     (with-temp-buffer
+                       (insert-file-contents "zeus.json")
+                       (buffer-string))))
+         (plan (alist-get 'plan zeus-json)))
+    (mapcar 'symbol-name (zeus--extract-commands plan))))
+
+(defun zeus--extract-commands (entries)
+  (-flatten (delq nil (mapcar
+                       (function (lambda (entry)
+                                   (cond
+                                    ((command-p entry) (car entry))
+                                    ((listp entry) (filter-commands entry)))))
+                       entries))))
+
+(defun zeus--completing-read ()
+  (if zeus-mode-completion-use-ido
+      'ido-completing-read 'completing-read))
+
+;;;###autoload
+(defun zeus-start ()
+  "Start the zeus server in the current directory using simple-status output"
+  (interactive)
+  (setq *zeus-server-process* (zeus--run "zeus-server" "*zeus-server*" "start" '("--simple-status")))
+  (pop-to-buffer *zeus-server-process*))
+
+(defun zeus-stop ()
+  "Shutdown the currently active zeus server cleanly"
+  (interactive)
+  (when *zeus-server-process*
+    (interrupt-process *zeus-server-process*)))
+
+(defun zeus-run-command (cmd)
+  "Run a command for zeus, i.e. zeus test to run the tests against the current zeus instance"
+  (interactive
+   (list (funcall (zeus--completing-read) "Command to run: " (zeus--available-commands))))
+  (let ((cmd-name (concat "zeus" cmd)))
+    (pop-to-buffer (zeus--run cmd-name "*zeus-command*" cmd))))
+
+(provide 'zeus-mode)

--- a/emacs/zeus.el
+++ b/emacs/zeus.el
@@ -35,13 +35,16 @@
   (-flatten (delq nil (mapcar
                        (function (lambda (entry)
                                    (cond
-                                    ((command-p entry) (car entry))
-                                    ((listp entry) (filter-commands entry)))))
+                                    ((zeus--command-p entry) (car entry))
+                                    ((listp entry) (zeus--extract-commands entry)))))
                        entries))))
 
 (defun zeus--completing-read ()
   (if zeus-mode-completion-use-ido
       'ido-completing-read 'completing-read))
+
+(defun zeus--command-p (entry)
+  (and (listp entry) (arrayp (cdr entry))))
 
 ;;;###autoload
 (defun zeus-start ()
@@ -63,4 +66,4 @@
   (let ((cmd-name (concat "zeus" cmd)))
     (pop-to-buffer (zeus--run cmd-name "*zeus-command*" cmd))))
 
-(provide 'zeus-mode)
+(provide 'zeus)

--- a/go/cmd/zeus/zeus.go
+++ b/go/cmd/zeus/zeus.go
@@ -23,6 +23,7 @@ var color bool = true
 func main() {
 	args := os.Args[1:]
 	configFile := "zeus.json"
+	simpleStatus := false
 	fileChangeDelay := filemonitor.DefaultFileChangeDelay
 
 	for ; args != nil && len(args) > 0 && args[0][0] == '-'; args = args[1:] {
@@ -30,6 +31,9 @@ func main() {
 		case "--no-color":
 			color = false
 			slog.DisableColor()
+		case "--simple-status":
+			slog.DisableColor()
+			simpleStatus = true
 		case "--log":
 			tracefile, err := os.OpenFile(args[1], os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 			if err == nil {
@@ -75,7 +79,7 @@ func main() {
 	} else if args[0] == "version" {
 		printVersion()
 	} else if args[0] == "start" {
-		os.Exit(zeusmaster.Run(configFile, fileChangeDelay))
+		os.Exit(zeusmaster.Run(configFile, fileChangeDelay, simpleStatus))
 	} else if args[0] == "init" {
 		zeusInit()
 	} else if args[0] == "commands" {

--- a/go/processtree/slavenode.go
+++ b/go/processtree/slavenode.go
@@ -64,6 +64,13 @@ const (
 	SCrashed  = "C"
 )
 
+var humanreadableStates = map[string]string{
+	SUnbooted: "unbooted",
+	SBooting:  "booted",
+	SReady:    "ready",
+	SCrashed:  "crashed",
+}
+
 func (tree *ProcessTree) NewSlaveNode(identifier string, parent *SlaveNode, monitor filemonitor.FileMonitor) *SlaveNode {
 	s := SlaveNode{}
 	s.needsRestart = make(chan bool, 1)
@@ -161,6 +168,10 @@ func (s *SlaveNode) State() string {
 	defer s.L.Unlock()
 
 	return s.state
+}
+
+func (s *SlaveNode) HumanReadableState() string {
+	return humanreadableStates[s.state]
 }
 
 func (s *SlaveNode) HasFeature(file string) bool {

--- a/go/statuschart/statuschart.go
+++ b/go/statuschart/statuschart.go
@@ -1,6 +1,7 @@
 package statuschart
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -31,7 +32,7 @@ type StatusChart struct {
 
 var theChart *StatusChart
 
-func Start(tree *processtree.ProcessTree, done chan bool) chan bool {
+func Start(tree *processtree.ProcessTree, done chan bool, simple bool) chan bool {
 	quit := make(chan bool)
 
 	theChart = &StatusChart{}
@@ -42,15 +43,41 @@ func Start(tree *processtree.ProcessTree, done chan bool) chan bool {
 	theChart.directLogger = slog.NewShinyLogger(os.Stdout, os.Stderr)
 	theChart.terminalSupported = ttyutils.IsTerminal(os.Stdout.Fd())
 
-	if theChart.terminalSupported {
-		ttyStart(tree, done, quit)
+	if simple {
+		startLineOutput(tree, done, quit)
 	} else {
-		stdoutStart(tree, done, quit)
+		if theChart.terminalSupported {
+			ttyStart(tree, done, quit)
+		} else {
+			stdoutStart(tree, done, quit)
+		}
 	}
 
 	go theChart.watchUpdates(tree.StateChanged)
 
 	return quit
+}
+
+func startLineOutput(tree *processtree.ProcessTree, done, quit chan bool) {
+	states := make(map[string]string)
+
+	go func() {
+		for {
+			select {
+			case <-quit:
+				done <- true
+				return
+			case <-theChart.update:
+				for name, slave := range tree.SlavesByName {
+					state, found := states[name]
+					if !found || (state != slave.State()) {
+						fmt.Println("node: " + name + " status: " + slave.HumanReadableState())
+						states[name] = slave.State()
+					}
+				}
+			}
+		}
+	}()
 }
 
 func (s *StatusChart) watchUpdates(updates <-chan bool) {

--- a/go/statuschart/statuschart.go
+++ b/go/statuschart/statuschart.go
@@ -71,7 +71,7 @@ func startLineOutput(tree *processtree.ProcessTree, done, quit chan bool) {
 				for name, slave := range tree.SlavesByName {
 					state, found := states[name]
 					if !found || (state != slave.State()) {
-						fmt.Println("node: " + name + " status: " + slave.HumanReadableState())
+						fmt.Println("environment: " + name + " status: " + slave.HumanReadableState())
 						states[name] = slave.State()
 					}
 				}

--- a/go/zeusmaster/zeusmaster.go
+++ b/go/zeusmaster/zeusmaster.go
@@ -25,7 +25,7 @@ const listenerPortVar = "ZEUS_NETWORK_FILE_MONITOR_PORT"
 // Leaving out SIGPIPE as that is a signal the master receives if a client process is killed.
 var terminatingSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGALRM, syscall.SIGTERM, syscall.SIGXCPU, syscall.SIGXFSZ, syscall.SIGVTALRM, syscall.SIGPROF, syscall.SIGUSR1, syscall.SIGUSR2}
 
-func Run(configFile string, fileChangeDelay time.Duration) int {
+func Run(configFile string, fileChangeDelay time.Duration, simpleStatus bool) int {
 	slog.Colorized("{green}Starting {yellow}Z{red}e{blue}u{magenta}s{green} server v" + zeusversion.VERSION)
 
 	zerror.Init()
@@ -44,7 +44,7 @@ func Run(configFile string, fileChangeDelay time.Duration) int {
 	defer monitor.Close()
 	defer slog.Suppress()
 	defer zerror.PrintFinalOutput()
-	defer exit(statuschart.Start(tree, done), done)
+	defer exit(statuschart.Start(tree, done, simpleStatus), done)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, terminatingSignals...)

--- a/go/zeusmaster/zeusmaster_test.go
+++ b/go/zeusmaster/zeusmaster_test.go
@@ -197,7 +197,7 @@ func TestZeusBoots(t *testing.T) {
 	enableTracing()
 	zexit := make(chan int)
 	go func() {
-		zexit <- zeusmaster.Run(filepath.Join(dir, "zeus.json"), filemonitor.DefaultFileChangeDelay)
+		zexit <- zeusmaster.Run(filepath.Join(dir, "zeus.json"), filemonitor.DefaultFileChangeDelay, false)
 	}()
 
 	expects := map[string]string{


### PR DESCRIPTION
The default zeus output requires an advanced terminal and is also hard to parse,
to make integration in emacs etc easier this adds a simple output format like

```
Starting Zeus server v0.15.13
node: boot status: unbooted
node: prerake status: unbooted
node: default_env status: unbooted
node: default_env status: booted
node: boot status: ready
node: prerake status: booted
node: default_env status: ready
node: prerake status: ready
node: default_env status: booted
node: default_env status: ready
node: default_env status: booted
node: default_env status: ready
```

which adds a line for each state change.