### PR TITLE
Show commands sorted for consistency & ease of use

### DIFF
--- a/go/processtree/processtree.go
+++ b/go/processtree/processtree.go
@@ -87,3 +87,19 @@ func (node *SlaveNode) restartNodesWithFeatures(tree *ProcessTree, files []strin
 		s.restartNodesWithFeatures(tree, files)
 	}
 }
+
+// We implement sort.Interface - Len, Less, and Swap - on list of commands so
+// we can use the sort package’s generic Sort function.
+type Commands []*CommandNode
+
+func (c Commands) Len() int {
+	return len(c)
+}
+
+func (c Commands) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c Commands) Less(i, j int) bool {
+	return c[i].Name < c[j].Name
+}

--- a/go/statuschart/tty.go
+++ b/go/statuschart/tty.go
@@ -2,6 +2,7 @@ package statuschart
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/burke/ttyutils"
@@ -100,6 +101,8 @@ func (s *StatusChart) lengthOfOutput() int {
 }
 
 func (s *StatusChart) drawCommands() {
+	sort.Sort(processtree.Commands(s.Commands))
+
 	for _, command := range s.Commands {
 		state := command.Parent.State()
 


### PR DESCRIPTION
On a project with custom commands added, it becomes difficult to find commands in a long list since the commands are shown unsorted. To make things worse, each time I restart Zeus, the commands are shown in a slightly different order, making it particularly hard to find. Our command list is 23 lines long, so you can imagine how tedious it is to be looking for a specific command.

While I would have preferred that commands were shown in groups, split by the environment and then sorted within each group, my Go skills are not yet sufficient for such wizardry.

If this gets accepted, I might look into breaking the command list by environment too :) 