### PR TITLE
Don't require pry; only patch it if it is loaded

### DIFF
--- a/rubygem/lib/zeus.rb
+++ b/rubygem/lib/zeus.rb
@@ -13,7 +13,6 @@ require 'set'
 require 'zeus/load_tracking'
 require 'zeus/plan'
 require 'zeus/version'
-require 'zeus/pry'
 
 module Zeus
   class << self

--- a/rubygem/lib/zeus/pry.rb
+++ b/rubygem/lib/zeus/pry.rb
@@ -1,13 +1,9 @@
-begin
-  require "pry"
-
+# Only patch Pry if it is loaded by the app.
+if defined?(Pry::Pager)
   class Pry::Pager
     def best_available
       # paging does not work in zeus so disable it
       NullPager.new(_pry_.output)
     end
   end
-
-rescue LoadError => e
-  # pry is not available, so no need to patch it
 end

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -95,6 +95,7 @@ module Zeus
 
     def default_bundle
       Bundler.require(:default)
+      require 'zeus/pry' if defined?(Pry)
       Zeus::LoadTracking.add_feature('./Gemfile.lock')
     end
 


### PR DESCRIPTION
This should help with issue #617 by not incidentally loading pry at whatever the newest (~> 0.10) gem available is before a bundle using an older pry version can be considered.