### PR TITLE
Add missing `r` to start up commands

### DIFF
--- a/examples/custom_plan/zeus.json
+++ b/examples/custom_plan/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+  "command": "ruby -rrubygems -r./custom_plan -eZeus.go",
 
   "plan": {
     "boot": {

--- a/examples/zeus.json
+++ b/examples/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -rzeus/rails -eZeus.go",
+  "command": "ruby -rrubygems -rzeus/rails -eZeus.go",
 
   "plan": {
     "boot": {


### PR DESCRIPTION
#### Description

It looks like the default command to start zeus does not work anymore with ruby 2.5.1.

After digging around and reading some comments ([1](https://github.com/burke/zeus/issues/237#issuecomment-357047144), [2](https://github.com/burke/zeus/issues/651#issuecomment-378656831)), I've noticed that the versions below 2.5.1 were accepting `-rubygems` as a parameter, but this does not work anymore with version 2.5.1 and above

```
quico: ~ » ruby -v
ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]
quico: ~ »  ruby -rubygems  -e 'puts 1+1'
2
quico: ~ » rbenv shell 2.5.1            
quico: ~ » ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
quico: ~ » ruby -rubygems  -e 'puts 1+1'
Traceback (most recent call last):
        1: from /home/nogates/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/home/nogates/.rbenv/versions/2.5.1/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
```

After adding that missing `r`, I can start `zeus` normally without having to do a `zeus init` and customizing the start command. Also, this works as well for versions prior 2.5.1

