### PR TITLE
Have Minitest actualy run tests instead of exiting

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -195,8 +195,7 @@ module Zeus
         # directly run the tests from here and exit with the status of the tests passing or failing
         case framework
         when :minitest5, :minitest_old
-          ARGV.replace(test_arguments)
-          exit
+          exit MiniTest::Unit.runner.run(test_arguments).to_i
         when :testunit1, :testunit2
           exit Test::Unit::AutoRunner.run(false, nil, test_arguments)
         else


### PR DESCRIPTION
I noticed that Minitest did not run any tests. 
I added this line to make sure they run instead of just exiting. 