### PR TITLE
replace -rubygems flag with -rrubygems flag

### DIFF
--- a/examples/custom_plan/zeus.json
+++ b/examples/custom_plan/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+  "command": "ruby -rrubygems -r./custom_plan -eZeus.go",
 
   "plan": {
     "boot": {

--- a/examples/zeus.json
+++ b/examples/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -rzeus/rails -eZeus.go",
+  "command": "ruby -rrubygems -rzeus/rails -eZeus.go",
 
   "plan": {
     "boot": {


### PR DESCRIPTION
Use of the `-rubygems` flag - which is generated by default in the `zeus.json` file - has been causing zeus to exit 1 since Rails 2.5 launched. For example, see this issue comment: https://github.com/burke/zeus/issues/237#issuecomment-423344927
More detail: https://www.engineyard.com/blog/goodbye-ubygems
TLDR: this flag hasn't been needed since Ruby 1.9, and you require Ruby 2.0 nowadays, so it's a no-brainer. 

This PR just grepped through the zourcecode and replaces all occurrences of `-rubygems` with `-rrubygems` - I didn't bother to install Go or test it. What could go wrong?
