### PR TITLE
Typo when requiring rubygems in zeus.json example files

### DIFF
--- a/examples/custom_plan/zeus.json
+++ b/examples/custom_plan/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -r./custom_plan -eZeus.go",
+  "command": "ruby -rrubygems -r./custom_plan -eZeus.go",
 
   "plan": {
     "boot": {

--- a/examples/zeus.json
+++ b/examples/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -rubygems -rzeus/rails -eZeus.go",
+  "command": "ruby -rrubygems -rzeus/rails -eZeus.go",
 
   "plan": {
     "boot": {


### PR DESCRIPTION
If you **just** installed Zeus, and try running it without `zeus init`, it fails because it cannot require `ubygems`.

The command that is shown in these files has the option `-rubygems` which seems to be missing one `r` (i.e. `-rrubygems`)