### PR TITLE
Fix compatibility with Pry 0.13+

### DIFF
--- a/rubygem/lib/zeus/pry.rb
+++ b/rubygem/lib/zeus/pry.rb
@@ -3,8 +3,11 @@ begin
 
   class Pry::Pager
     def best_available
+      # Versions of Pry prior to 0.13 define `Pry::Pager#_pry_`
+      # while versions after that define `Pry::Pager#pry_instance`
+      pry = respond_to?(:pry_instance) ? pry_instance : _pry_
       # paging does not work in zeus so disable it
-      NullPager.new(_pry_.output)
+      NullPager.new(pry.output)
     end
   end
 


### PR DESCRIPTION
This change allows Zeus to work with both Pry v0.13+ as well as
versions prior to that.

Fixes #674