### PR TITLE
Use defined? instead of respond_to? in Pry monkeypatch

### DIFF
--- a/rubygem/lib/zeus/pry.rb
+++ b/rubygem/lib/zeus/pry.rb
@@ -5,7 +5,7 @@ begin
     def best_available
       # Versions of Pry prior to 0.13 define `Pry::Pager#_pry_`
       # while versions after that define `Pry::Pager#pry_instance`
-      pry = respond_to?(:pry_instance) ? pry_instance : _pry_
+      pry = defined?(pry_instance) ? pry_instance : _pry_
       # paging does not work in zeus so disable it
       NullPager.new(pry.output)
     end


### PR DESCRIPTION
I'm not clear on what is going on, though currently I'm getting errors on the latest version of pry when I try to do anything in a console:
```
(pry) output error: #<NameError: undefined local variable or method `_pry_' for #<Pry::Pager:0x00007fe77e5c8b50>
```
It seems like `pry_instance` is defined as an instance variable when this is run, so `respond_to?` doesn't pick it up. This change to `defined?` will work for instance variables AND method definitions to cover our bases.