### PR TITLE
Replacing calls to the alias File.exists? (deprecated since Ruby v3.x) with File.exist?

### DIFF
--- a/rubygem/lib/zeus/m.rb
+++ b/rubygem/lib/zeus/m.rb
@@ -10,7 +10,7 @@ require "zeus/m/test_method"
 # To avoid possible "you've activated X; gemfile specifies Y" errors, we actually scan
 # Gemfile.lock for a specific version, and require exactly that version if present.
 gemfile_lock = ROOT_PATH + "/Gemfile.lock"
-if File.exists?(gemfile_lock)
+if File.exist?(gemfile_lock)
   version = File.read(ROOT_PATH + "/Gemfile.lock").
     scan(/\bmethod_source\s*\(([\d\.]+)\)/).flatten[0]
 

--- a/rubygem/lib/zeus/rails.rb
+++ b/rubygem/lib/zeus/rails.rb
@@ -1,6 +1,6 @@
 def find_rails_path(root_path)
   paths = %w(spec/dummy test/dummy .)
-  paths.find { |path| File.exists?(File.expand_path(path, root_path)) }
+  paths.find { |path| File.exist?(File.expand_path(path, root_path)) }
 end
 
 ROOT_PATH = File.expand_path(Dir.pwd)
@@ -210,13 +210,13 @@ module Zeus
       if ENV['RAILS_TEST_HELPER']
         require ENV['RAILS_TEST_HELPER']
       else
-        if File.exists?(ROOT_PATH + "/spec/rails_helper.rb")
+        if File.exist?(ROOT_PATH + "/spec/rails_helper.rb")
           # RSpec >= 3.0+
           require 'rails_helper'
-        elsif File.exists?(ROOT_PATH + "/spec/spec_helper.rb")
+        elsif File.exist?(ROOT_PATH + "/spec/spec_helper.rb")
           # RSpec < 3.0
           require 'spec_helper'
-        elsif File.exists?(ROOT_PATH + "/test/minitest_helper.rb")
+        elsif File.exist?(ROOT_PATH + "/test/minitest_helper.rb")
           require 'minitest_helper'
         else
           require 'test_helper'


### PR DESCRIPTION
### Description
`File.exists?` was aliased to `File.exist?` in versions of Ruby up to 3.1.
`File.exists?` is no longer supported since Ruby 3.2.
